### PR TITLE
focustime: Configurable timezone, Japanese weekday labels, and clearer week UI

### DIFF
--- a/focustime/main.go
+++ b/focustime/main.go
@@ -10,11 +10,10 @@ import (
 )
 
 func main() {
-	homeDir, err := os.UserHomeDir()
+	cfg, err := src.ResolveStartCfg(src.StartCfg{})
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("focustime: %v", err)
 	}
-	cfg := src.StartCfg{HomeDir: homeDir}
 	appCmd := src.NewAppCmd(cfg)
 	if err := appCmd.Run(context.Background(), os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/focustime/src/cli.go
+++ b/focustime/src/cli.go
@@ -13,6 +13,27 @@ func rootHelpAction(ctx context.Context, c *cli.Command) error {
 	return cli.ShowAppHelp(c)
 }
 
+func configShowAction(cfg StartCfg) cli.ActionFunc {
+	return func(ctx context.Context, c *cli.Command) error {
+		b, err := EffectiveConfigJSON(cfg)
+		if err != nil {
+			return err
+		}
+		_, err = c.Writer.Write(append(b, '\n'))
+		return err
+	}
+}
+
+func configEditAction(cfg StartCfg) cli.ActionFunc {
+	return func(ctx context.Context, c *cli.Command) error {
+		if err := ConfigEdit(cfg); err != nil {
+			return err
+		}
+		fmt.Fprintln(c.Writer, "Saved config.")
+		return nil
+	}
+}
+
 func subcommandHelpAction(ctx context.Context, c *cli.Command) error {
 	return cli.ShowSubcommandHelp(c)
 }
@@ -44,6 +65,18 @@ func NewAppCmd(cfg StartCfg) *cli.Command {
 				Usage:     "Log time to an area for today",
 				ArgsUsage: "<time_amt> <area_idx>",
 				Action:    logAction(cfg),
+			},
+			{
+				Name:  "config",
+				Usage: "Show or edit focustime JSON config (timezone)",
+				Commands: []*cli.Command{
+					{
+						Name:   "edit",
+						Usage:  "Edit config.json in your editor",
+						Action: configEditAction(cfg),
+					},
+				},
+				Action: configShowAction(cfg),
 			},
 			{
 				Name:  "areas",
@@ -188,7 +221,7 @@ func editAction(cfg StartCfg) cli.ActionFunc {
 		arg := c.Args().First()
 		var woy WoY
 		if arg == "" {
-			woy = TimeToWoY(time.Now().UTC())
+			woy = TimeToWoY(time.Now(), cfg.Location())
 		} else {
 			year, week, err := ParseYearWWeek(arg)
 			if err != nil {
@@ -202,7 +235,7 @@ func editAction(cfg StartCfg) cli.ActionFunc {
 
 func todayAction(cfg StartCfg) cli.ActionFunc {
 	return func(ctx context.Context, c *cli.Command) error {
-		out, err := TodayReport(cfg, time.Now().UTC())
+		out, err := TodayReport(cfg, time.Now())
 		if err != nil {
 			return err
 		}
@@ -213,7 +246,7 @@ func todayAction(cfg StartCfg) cli.ActionFunc {
 
 func weekAction(cfg StartCfg) cli.ActionFunc {
 	return func(ctx context.Context, c *cli.Command) error {
-		out, err := CurrentWeekReport(cfg, time.Now().UTC())
+		out, err := CurrentWeekReport(cfg, time.Now())
 		if err != nil {
 			return err
 		}

--- a/focustime/src/cli_test.go
+++ b/focustime/src/cli_test.go
@@ -94,8 +94,9 @@ func TestCLIWeekActionWritesReport(t *testing.T) {
 	err = app.Run(context.Background(), []string{"focustime", "week"})
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "# focustime week view")
-	require.Contains(t, stdout.String(), "# Columns: Area | Mon | Tue | Wed | Thu | Fri | Sat | Sun")
-	require.Contains(t, stdout.String(), "C  |")
+	require.Contains(t, stdout.String(), "# Area")
+	require.Contains(t, stdout.String(), "|   日 |   月 |   火 |   水 |   木 |   金 |   土")
+	require.Contains(t, stdout.String(), "C     |")
 }
 
 // TestCLIAreasEditActionUpdatesAreas verifies end-to-end CLI behavior for

--- a/focustime/src/cli_test.go
+++ b/focustime/src/cli_test.go
@@ -95,7 +95,13 @@ func TestCLIWeekActionWritesReport(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "# focustime week view")
 	require.Contains(t, stdout.String(), "# Area")
-	require.Contains(t, stdout.String(), "|   日 |   月 |   火 |   水 |   木 |   金 |   土")
+	require.Contains(t, stdout.String(), "日")
+	require.Contains(t, stdout.String(), "月")
+	require.Contains(t, stdout.String(), "火")
+	require.Contains(t, stdout.String(), "水")
+	require.Contains(t, stdout.String(), "木")
+	require.Contains(t, stdout.String(), "金")
+	require.Contains(t, stdout.String(), "土")
 	require.Contains(t, stdout.String(), "C     |")
 }
 

--- a/focustime/src/cli_test.go
+++ b/focustime/src/cli_test.go
@@ -17,7 +17,14 @@ func setupCLIApp(t *testing.T) (StartCfg, *bytes.Buffer, *bytes.Buffer, *cli.Com
 	t.Helper()
 	newHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", newHome)
-	cfg := StartCfg{HomeDir: newHome}
+	xdgCfg := filepath.Join(newHome, "xdg_config")
+	t.Setenv("XDG_CONFIG_HOME", xdgCfg)
+	require.NoError(t, os.MkdirAll(filepath.Join(xdgCfg, "focustime"), 0o755))
+	cfgPath := filepath.Join(xdgCfg, "focustime", "config.json")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`{"timezone":"UTC"}`+"\n"), 0o644))
+
+	cfg, err := ResolveStartCfg(StartCfg{HomeDir: newHome})
+	require.NoError(t, err)
 
 	reg := FocusAreas{
 		Areas:       []string{"A", "B", "C"},
@@ -46,8 +53,8 @@ func TestCLILogActionSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "Logged 45m to area 1")
 
-	now := time.Now().UTC()
-	woy := TimeToWoY(now)
+	now := time.Now().In(cfg.Location())
+	woy := TimeToWoY(now, cfg.Location())
 	yf, err := LoadYearFile(cfg, woy.Year)
 	require.NoError(t, err)
 	week := yf.Weeks[woy.WeekIndex()]
@@ -81,6 +88,7 @@ func TestCLITodayActionWritesReport(t *testing.T) {
 	err = app.Run(context.Background(), []string{"focustime", "today"})
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "Today (")
+	require.Contains(t, stdout.String(), " UTC)")
 	require.Contains(t, stdout.String(), "0 → A: 30m")
 	require.Contains(t, stdout.String(), "Total: 30m")
 }
@@ -134,6 +142,26 @@ func TestCLIAreasEditActionUpdatesAreas(t *testing.T) {
 	reg, err := LoadAreasFile(cfg)
 	require.NoError(t, err)
 	require.Equal(t, []string{"Deep Work", "Code Review", "Exercise"}, reg.Areas)
+}
+
+func TestCLIConfigShowPrintsJSON(t *testing.T) {
+	_, stdout, _, app := setupCLIApp(t)
+	err := app.Run(context.Background(), []string{"focustime", "config"})
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), `"timezone"`)
+	require.Contains(t, stdout.String(), "UTC")
+}
+
+func TestCLIConfigEditRejectsInvalidTimezone(t *testing.T) {
+	_, _, _, app := setupCLIApp(t)
+	editorScript := filepath.Join(t.TempDir(), "fake-editor.sh")
+	script := "#!/usr/bin/env bash\ncat <<'EOF' > \"$1\"\n{\"timezone\":\"NotA/RealZone\"}\nEOF\n"
+	require.NoError(t, os.WriteFile(editorScript, []byte(script), 0o755))
+	t.Setenv("EDITOR", editorScript)
+
+	err := app.Run(context.Background(), []string{"focustime", "config", "edit"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NotA/RealZone")
 }
 
 func TestCLIAreasSaveLayoutActionSavesAndSetsLastUsed(t *testing.T) {

--- a/focustime/src/focustime.go
+++ b/focustime/src/focustime.go
@@ -13,10 +13,233 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
-// StartCfg holds startup configuration. HomeDir is used for XDG fallbacks
-// when env vars (e.g. XDG_DATA_HOME) are unset.
+// StartCfg holds startup configuration. HomeDir is optional: when empty,
+// os.UserHomeDir is used for XDG fallbacks. Timezone is an IANA name
+// (persisted in config.json). Loc is derived from Timezone for runtime; if set
+// with Loc != nil, ResolveStartCfg skips file/timezone resolution (tests).
 type StartCfg struct {
-	HomeDir string
+	HomeDir  string         `json:"-"`
+	Timezone string         `json:"timezone"`
+	Loc      *time.Location `json:"-"`
+}
+
+// EffectiveHomeDir returns HomeDir or os.UserHomeDir when HomeDir is empty.
+func EffectiveHomeDir(cfg StartCfg) (string, error) {
+	if cfg.HomeDir != "" {
+		return cfg.HomeDir, nil
+	}
+	return os.UserHomeDir()
+}
+
+func fillEffectiveHomeDir(cfg *StartCfg) error {
+	if cfg.HomeDir != "" {
+		return nil
+	}
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	cfg.HomeDir = h
+	return nil
+}
+
+// MergeTimezone returns raw if non-empty, else America/Chicago.
+func MergeTimezone(raw string) string {
+	if raw != "" {
+		return raw
+	}
+	return "America/Chicago"
+}
+
+// ValidateAndLocateTimezone loads an IANA timezone name.
+func ValidateAndLocateTimezone(tz string) (*time.Location, error) {
+	if tz == "" {
+		return nil, fmt.Errorf("timezone is empty")
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, err
+	}
+	return loc, nil
+}
+
+// ConfigFilePath returns the path to focustime config.json under XDG_CONFIG_HOME.
+func ConfigFilePath(cfg StartCfg) (string, error) {
+	c := cfg
+	if err := fillEffectiveHomeDir(&c); err != nil {
+		return "", err
+	}
+	xdg, err := XdgConfigHome(c)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(xdg, "focustime", "config.json"), nil
+}
+
+// readMergedTimezoneFromDisk returns the effective timezone string from
+// config.json or default. Missing file is not an error.
+func readMergedTimezoneFromDisk(cfg StartCfg) (string, error) {
+	path, err := ConfigFilePath(cfg)
+	if err != nil {
+		return "", err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MergeTimezone(""), nil
+		}
+		return "", err
+	}
+	var s StartCfg
+	if err := json.Unmarshal(b, &s); err != nil {
+		return "", fmt.Errorf("config file: invalid JSON: %w", err)
+	}
+	return MergeTimezone(s.Timezone), nil
+}
+
+// ResolveStartCfg fills HomeDir when empty, then resolves Loc from Loc (passthrough),
+// Timezone (caller override), or config.json / default Chicago.
+func ResolveStartCfg(base StartCfg) (StartCfg, error) {
+	copy := base
+	if err := fillEffectiveHomeDir(&copy); err != nil {
+		return StartCfg{}, err
+	}
+	if copy.Loc != nil {
+		return copy, nil
+	}
+	if copy.Timezone != "" {
+		loc, err := ValidateAndLocateTimezone(copy.Timezone)
+		if err != nil {
+			return StartCfg{}, fmt.Errorf("timezone %q: %w", copy.Timezone, err)
+		}
+		return StartCfg{
+			HomeDir:  copy.HomeDir,
+			Timezone: copy.Timezone,
+			Loc:      loc,
+		}, nil
+	}
+	tz, err := readMergedTimezoneFromDisk(copy)
+	if err != nil {
+		return StartCfg{}, err
+	}
+	loc, err := ValidateAndLocateTimezone(tz)
+	if err != nil {
+		return StartCfg{}, fmt.Errorf("config timezone %q: %w", tz, err)
+	}
+	return StartCfg{
+		HomeDir:  copy.HomeDir,
+		Timezone: tz,
+		Loc:      loc,
+	}, nil
+}
+
+// EffectiveConfigJSON returns the on-disk or default timezone as pretty JSON
+// for `focustime config` (merged effective values only).
+func EffectiveConfigJSON(cfg StartCfg) ([]byte, error) {
+	c := cfg
+	if err := fillEffectiveHomeDir(&c); err != nil {
+		return nil, err
+	}
+	tz, err := readMergedTimezoneFromDisk(c)
+	if err != nil {
+		return nil, err
+	}
+	out := StartCfg{Timezone: tz}
+	return json.MarshalIndent(out, "", "  ")
+}
+
+// SaveStartCfgFile writes timezone to config.json atomically after validation.
+func SaveStartCfgFile(cfg StartCfg, toSave StartCfg) error {
+	tz := MergeTimezone(toSave.Timezone)
+	if _, err := ValidateAndLocateTimezone(tz); err != nil {
+		return fmt.Errorf("invalid timezone %q: %w", tz, err)
+	}
+	path, err := ConfigFilePath(cfg)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	payload := StartCfg{Timezone: tz}
+	jsonBz, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmpPath := filepath.Join(dir, fmt.Sprintf("config.json.%d.tmp", os.Getpid()))
+	if err := os.WriteFile(tmpPath, jsonBz, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// ConfigEdit opens config.json in $EDITOR; only valid JSON and timezone persist.
+func ConfigEdit(cfg StartCfg) error {
+	c := cfg
+	if err := fillEffectiveHomeDir(&c); err != nil {
+		return err
+	}
+	path, err := ConfigFilePath(c)
+	if err != nil {
+		return err
+	}
+	var seed []byte
+	if b, err := os.ReadFile(path); err == nil {
+		var s StartCfg
+		if json.Unmarshal(b, &s) == nil {
+			s.Timezone = MergeTimezone(s.Timezone)
+			seed, err = json.MarshalIndent(StartCfg{Timezone: s.Timezone}, "", "  ")
+			if err != nil {
+				return err
+			}
+			seed = append(seed, '\n')
+		} else {
+			seed = append([]byte(nil), b...)
+		}
+	} else if os.IsNotExist(err) {
+		seed, err = json.MarshalIndent(StartCfg{Timezone: MergeTimezone("")}, "", "  ")
+		if err != nil {
+			return err
+		}
+		seed = append(seed, '\n')
+	} else {
+		return err
+	}
+
+	tmp, err := os.CreateTemp("", "focustime-config_*")
+	if err != nil {
+		return err
+	}
+	tempPath := tmp.Name()
+	defer os.Remove(tempPath)
+	if _, err := tmp.Write(seed); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := LaunchEditor(tempPath); err != nil {
+		return fmt.Errorf("editor exited with error: %w", err)
+	}
+	fileBz, err := os.ReadFile(tempPath)
+	if err != nil {
+		return err
+	}
+	var parsed StartCfg
+	if err := json.Unmarshal(fileBz, &parsed); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	return SaveStartCfgFile(c, parsed)
+}
+
+// Location returns Loc or UTC when Loc is nil.
+func (c StartCfg) Location() *time.Location {
+	if c.Loc != nil {
+		return c.Loc
+	}
+	return time.UTC
 }
 
 // FocusAreas is the areas.json schema: display names, saved layouts,
@@ -35,7 +258,10 @@ func LoadAreasFile(cfg StartCfg) (FocusAreas, error) {
 		AreaLayouts:             [][]int{},
 		LastUsedAreaLayoutIndex: 0,
 	}
-	xdgDataHome := XdgDataHome(cfg)
+	xdgDataHome, err := XdgDataHome(cfg)
+	if err != nil {
+		return fresh, err
+	}
 	fileInfo, err := os.Stat(xdgDataHome)
 	if err != nil && os.IsNotExist(err) {
 		err := os.MkdirAll(xdgDataHome, 0o755)
@@ -53,7 +279,11 @@ func LoadAreasFile(cfg StartCfg) (FocusAreas, error) {
 		return fresh, err
 	}
 
-	fp := filepath.Join(DirFTData(cfg), "areas.json")
+	dir, err := DirFTData(cfg)
+	if err != nil {
+		return fresh, err
+	}
+	fp := filepath.Join(dir, "areas.json")
 	fileInfo, err = os.Stat(fp)
 	switch {
 	case err != nil && os.IsNotExist(err):
@@ -84,7 +314,10 @@ func SaveAreasFile(cfg StartCfg, reg FocusAreas) error {
 	if err := CreateFocusTimeDir(cfg); err != nil {
 		return err
 	}
-	dir := DirFTData(cfg)
+	dir, err := DirFTData(cfg)
+	if err != nil {
+		return err
+	}
 	jsonBz, err := json.MarshalIndent(reg, "", "  ")
 	if err != nil {
 		return err
@@ -164,7 +397,10 @@ func RemoveArea(reg FocusAreas, index int) (FocusAreas, error) {
 // CreateFocusTimeDir: Creates the primary data directory if it does not already
 // exist. Otherwise, does nothing.
 func CreateFocusTimeDir(cfg StartCfg) error {
-	ftDir := DirFTData(cfg)
+	ftDir, err := DirFTData(cfg)
+	if err != nil {
+		return err
+	}
 	info, err := os.Stat(ftDir)
 	switch {
 	case err == nil && info.IsDir():
@@ -183,51 +419,67 @@ func CreateFocusTimeDir(cfg StartCfg) error {
 
 // XdgConfigHome returns the XDG configuration directory, falling back
 // to $HOME/.config when XDG_CONFIG_HOME is not set.
-func XdgConfigHome(cfg StartCfg) string {
+func XdgConfigHome(cfg StartCfg) (string, error) {
 	if v := os.Getenv("XDG_CONFIG_HOME"); v != "" {
-		return v
+		return v, nil
 	}
-	home := cfg.HomeDir
-	return filepath.Join(home, ".config")
+	home, err := EffectiveHomeDir(cfg)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config"), nil
 }
 
 // XdgDataHome returns the XDG data directory, falling back to
 // $HOME/.local/share when XDG_DATA_HOME is not set.
 // Data holds persistent downloaded assets.
-func XdgDataHome(cfg StartCfg) string {
+func XdgDataHome(cfg StartCfg) (string, error) {
 	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
-		return v
+		return v, nil
 	}
-	home := cfg.HomeDir
-	return filepath.Join(home, ".local", "share")
+	home, err := EffectiveHomeDir(cfg)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".local", "share"), nil
 }
 
 // XdgStateHome returns the XDG state directory, falling back to
 // $HOME/.local/state when XDG_STATE_HOME is not set.
 // State in the XDG spec is runtime info that persists but is not user-editable.
 // It typically holds session state like logs and runtime history.
-func XdgStateHome(cfg StartCfg) string {
+func XdgStateHome(cfg StartCfg) (string, error) {
 	if v := os.Getenv("XDG_STATE_HOME"); v != "" {
-		return v
+		return v, nil
 	}
-	home := cfg.HomeDir
-	return filepath.Join(home, ".local", "state")
+	home, err := EffectiveHomeDir(cfg)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".local", "state"), nil
 }
 
 // XdgCacheHome returns the XDG cache directory, falling back to $HOME/.cache
 // when XDG_CACHE_HOME is not set. Cache is used for ephemeral speed-ups. Cache
 // is meant to be safe to delete at all times.
-func XdgCacheHome(cfg StartCfg) string {
+func XdgCacheHome(cfg StartCfg) (string, error) {
 	if v := os.Getenv("XDG_CACHE_HOME"); v != "" {
-		return v
+		return v, nil
 	}
-	home := cfg.HomeDir
-	return filepath.Join(home, ".cache")
+	home, err := EffectiveHomeDir(cfg)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache"), nil
 }
 
 // DirFTData returns the "$XDG_DATA_HOME/focustime" directory.
-func DirFTData(cfg StartCfg) string {
-	return filepath.Join(XdgDataHome(cfg), "focustime")
+func DirFTData(cfg StartCfg) (string, error) {
+	d, err := XdgDataHome(cfg)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(d, "focustime"), nil
 }
 
 // WeekValues holds one week's data. Areas is the ordered list of area IDs
@@ -283,10 +535,13 @@ func ParseYearWWeek(s string) (year, week int, err error) {
 	return year, week, nil
 }
 
-// TimeToWoY converts t to its ISO week-of-year in UTC and returns the
-// corresponding WoY value.
-func TimeToWoY(t time.Time) WoY {
-	t = t.UTC()
+// TimeToWoY converts t to its ISO week-of-year in loc and returns the
+// corresponding WoY value. A nil loc is treated as UTC.
+func TimeToWoY(t time.Time, loc *time.Location) WoY {
+	if loc == nil {
+		loc = time.UTC
+	}
+	t = t.In(loc)
 	year, weekOfYear := t.ISOWeek()
 	return WoY{
 		Year: year,
@@ -362,8 +617,9 @@ func LogTime(cfg StartCfg, durationStr string, areaID int) (int, error) {
 		return 0, fmt.Errorf("area index %d out of range [0, %d)",
 			areaID, len(reg.Areas))
 	}
-	now := time.Now().UTC()
-	woy := TimeToWoY(now)
+	loc := cfg.Location()
+	now := time.Now().In(loc)
+	woy := TimeToWoY(now, loc)
 	yf, err := LoadYearFile(cfg, woy.Year)
 	if err != nil {
 		return 0, err
@@ -394,8 +650,8 @@ func CurrentWeekReport(cfg StartCfg, now time.Time) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	now = now.UTC()
-	woy := TimeToWoY(now)
+	now = now.In(cfg.Location())
+	woy := TimeToWoY(now, cfg.Location())
 	yf, err := LoadYearFile(cfg, woy.Year)
 	if err != nil {
 		return "", err
@@ -407,9 +663,8 @@ func CurrentWeekReport(cfg StartCfg, now time.Time) (string, error) {
 	}
 	areaNames := resolveAreaNames(reg, week.Areas)
 	weekStart := weekStartFor(woy.Year, woy.Week)
-	nowLocal := now.In(time.Local)
 	return RenderWeekBuffer(*week, areaNames, woy.Year, woy.WeekIndex(),
-		weekStart, nowLocal), nil
+		weekStart, now), nil
 }
 
 // TodayReport returns today's logged values by area for the current week.
@@ -418,8 +673,8 @@ func TodayReport(cfg StartCfg, now time.Time) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	now = now.UTC()
-	woy := TimeToWoY(now)
+	now = now.In(cfg.Location())
+	woy := TimeToWoY(now, cfg.Location())
 	yf, err := LoadYearFile(cfg, woy.Year)
 	if err != nil {
 		return "", err
@@ -428,13 +683,14 @@ func TodayReport(cfg StartCfg, now time.Time) (string, error) {
 	dayIdx := WeekdayToDayIndex(now.Weekday())
 	dayLabel := now.Weekday().String()
 	dateLabel := now.Format("2006-01-02")
+	timeLabel := now.Format("15:04:05 MST")
 	if week == nil {
-		return fmt.Sprintf("Today (%s, %s): no data yet.\n",
-			dateLabel, dayLabel), nil
+		return fmt.Sprintf("Today (%s, %s, %s): no data yet.\n",
+			dateLabel, dayLabel, timeLabel), nil
 	}
 	areaNames := resolveAreaNames(reg, week.Areas)
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Today (%s, %s)\n", dateLabel, dayLabel))
+	b.WriteString(fmt.Sprintf("Today (%s, %s, %s)\n", dateLabel, dayLabel, timeLabel))
 	hasData := false
 	total := 0
 	for row := range week.Areas {
@@ -465,7 +721,11 @@ func LoadYearFile(cfg StartCfg, year int) (YearFile, error) {
 	if err := CreateFocusTimeDir(cfg); err != nil {
 		return fresh, err
 	}
-	fp := filepath.Join(DirFTData(cfg), fmt.Sprintf("%d.json", year))
+	dir, err := DirFTData(cfg)
+	if err != nil {
+		return fresh, err
+	}
+	fp := filepath.Join(dir, fmt.Sprintf("%d.json", year))
 	fileBz, err := os.ReadFile(fp)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -494,7 +754,10 @@ func SaveYearFile(cfg StartCfg, yf YearFile) error {
 	if err := CreateFocusTimeDir(cfg); err != nil {
 		return err
 	}
-	dir := DirFTData(cfg)
+	dir, err := DirFTData(cfg)
+	if err != nil {
+		return err
+	}
 	jsonBz, err := json.MarshalIndent(yf, "", "  ")
 	if err != nil {
 		return err
@@ -875,10 +1138,10 @@ func WeekEdit(cfg StartCfg, woy WoY) error {
 	}
 	// 7. Compute week start (Monday of that ISO week)
 	weekStart := weekStartFor(woy.Year, woy.Week)
-	nowLocal := time.Now().In(time.Local)
+	nowInLoc := time.Now().In(cfg.Location())
 	// 8. Render buffer
 	buf := RenderWeekBuffer(*week, areaNames, woy.Year, woy.WeekIndex(), weekStart,
-		nowLocal)
+		nowInLoc)
 	// 9. Create temp file, write buf
 	pattern := fmt.Sprintf("focustime-%dw%d_*", woy.Year, woy.Week)
 	tmp, err := os.CreateTemp("", pattern)

--- a/focustime/src/focustime.go
+++ b/focustime/src/focustime.go
@@ -231,7 +231,7 @@ func DirFTData(cfg StartCfg) string {
 }
 
 // WeekValues holds one week's data. Areas is the ordered list of area IDs
-// (rows). Values is [areaIdx][dayIdx], Mon=0..Sun=6; nil = unset.
+// (rows). Values is [areaIdx][dayIdx], Sun=0..Sat=6; nil = unset.
 type WeekValues struct {
 	Areas  []int    `json:"areas"`
 	Values [][]*int `json:"values"`
@@ -310,9 +310,11 @@ func ParseDurationToMinutes(s string) (int, error) {
 	return int(d / time.Minute), nil
 }
 
-// WeekdayToDayIndex maps a Go weekday to Mon=0..Sun=6.
+var weekdayLabelsJP = [7]string{"日", "月", "火", "水", "木", "金", "土"}
+
+// WeekdayToDayIndex maps a Go weekday to Sun=0..Sat=6.
 func WeekdayToDayIndex(wd time.Weekday) int {
-	return (int(wd) + 6) % 7
+	return int(wd)
 }
 
 func resolveAreaNames(reg FocusAreas, areaIDs []int) []string {
@@ -574,17 +576,7 @@ func RenderWeekBuffer(week WeekValues, areaNames []string, year, weekIndex int,
 	areaIDList := strings.Join(areaIDs, ", ")
 	weekNum := weekIndex + 1
 
-	var b strings.Builder
-	b.WriteString("# focustime week view\n")
-	b.WriteString("# Week index: " + fmt.Sprintf("%dw%d", year, weekNum) + " (Week starting: " + weekStart.Format("2006-01-02") + ")\n")
-	b.WriteString("# Areas (row order): " + areaIDList + "\n")
-	b.WriteString("# Units: minutes\n")
-	b.WriteString("#\n")
-	b.WriteString("# Edit numeric cells only. Empty = unset.\n")
-	b.WriteString("#\n")
-	b.WriteString("# Columns: Area | Mon | Tue | Wed | Thu | Fri | Sat | Sun\n")
-
-	maxAreaWidth := 0
+	maxAreaWidth := runewidth.StringWidth("Area")
 	for _, name := range areaNames {
 		if w := runewidth.StringWidth(name); w > maxAreaWidth {
 			maxAreaWidth = w
@@ -592,11 +584,36 @@ func RenderWeekBuffer(week WeekValues, areaNames []string, year, weekIndex int,
 	}
 	areaColWidth := maxAreaWidth + 1
 	const numWidth = 4
+
+	var b strings.Builder
+	b.WriteString("# focustime week view\n")
+	b.WriteString("# Week index: " + fmt.Sprintf("%dw%d", year, weekNum) + " (Week starting: " + weekStart.Format("2006-01-02") + ")\n")
+	b.WriteString("# Areas (row order): " + areaIDList + "\n")
+	b.WriteString("# Units: minutes\n")
+	b.WriteString("# Edit numeric cells only. Empty = unset.\n")
+	b.WriteString("#\n")
+	const headerPrefix = "# "
+	b.WriteString(headerPrefix)
+	headerAreaColWidth := areaColWidth - runewidth.StringWidth(headerPrefix)
+	if headerAreaColWidth < runewidth.StringWidth("Area") {
+		headerAreaColWidth = runewidth.StringWidth("Area")
+	}
+	b.WriteString(padRightDisplayWidth("Area", headerAreaColWidth))
+	b.WriteString(" |")
+	for i, day := range weekdayLabelsJP {
+		b.WriteString(" ")
+		b.WriteString(padLeftDisplayWidth(day, numWidth))
+		if i < len(weekdayLabelsJP)-1 {
+			b.WriteString(" |")
+		}
+	}
+	b.WriteString("\n")
+
 	for row := 0; row < len(areaNames); row++ {
 		name := areaNames[row]
 		rowStr := padRightDisplayWidth(name, areaColWidth) + " |"
 		vals := week.Values[row]
-		for d := 0; d < 7; d++ {
+		for d := 0; d < len(weekdayLabelsJP); d++ {
 			rowStr += " "
 			if d < len(vals) && vals[d] != nil {
 				rowStr += fmt.Sprintf("%*d", numWidth, *vals[d])
@@ -619,6 +636,15 @@ func padRightDisplayWidth(s string, width int) string {
 		return s
 	}
 	return s + strings.Repeat(" ", width-w)
+}
+
+// padLeftDisplayWidth pads s on the left to at least width display cells.
+func padLeftDisplayWidth(s string, width int) string {
+	w := runewidth.StringWidth(s)
+	if w >= width {
+		return s
+	}
+	return strings.Repeat(" ", width-w) + s
 }
 
 // ParseWeekBuffer parses the edited buffer back into WeekValues.
@@ -651,8 +677,8 @@ func ParseWeekBuffer(buf []byte, areaNames []string, areaIDs []int) (WeekValues,
 		if areaName != areaNames[i] {
 			return WeekValues{}, fmt.Errorf("row %d: expected area %q, got %q", i+1, areaNames[i], areaName)
 		}
-		row := make([]*int, 7)
-		for d := 0; d < 7; d++ {
+		row := make([]*int, len(weekdayLabelsJP))
+		for d := 0; d < len(weekdayLabelsJP); d++ {
 			cell := strings.TrimSpace(parts[d+1])
 			if cell == "" {
 				row[d] = nil

--- a/focustime/src/focustime.go
+++ b/focustime/src/focustime.go
@@ -407,8 +407,9 @@ func CurrentWeekReport(cfg StartCfg, now time.Time) (string, error) {
 	}
 	areaNames := resolveAreaNames(reg, week.Areas)
 	weekStart := weekStartFor(woy.Year, woy.Week)
+	nowLocal := now.In(time.Local)
 	return RenderWeekBuffer(*week, areaNames, woy.Year, woy.WeekIndex(),
-		weekStart), nil
+		weekStart, nowLocal), nil
 }
 
 // TodayReport returns today's logged values by area for the current week.
@@ -568,7 +569,7 @@ func FindOrCreateWeek(yf *YearFile, weekIndex int, defaultAreas []int) (*WeekVal
 
 // RenderWeekBuffer produces the week view text format per spec §4.1.
 func RenderWeekBuffer(week WeekValues, areaNames []string, year, weekIndex int,
-	weekStart time.Time) string {
+	weekStart time.Time, nowLocal time.Time) string {
 	areaIDs := make([]string, len(week.Areas))
 	for i, id := range week.Areas {
 		areaIDs[i] = fmt.Sprint(id)
@@ -600,9 +601,14 @@ func RenderWeekBuffer(week WeekValues, areaNames []string, year, weekIndex int,
 	}
 	b.WriteString(padRightDisplayWidth("Area", headerAreaColWidth))
 	b.WriteString(" |")
+	todayIdx, hasTodayMarker := headerTodayMarkerDayIndex(year, weekIndex, nowLocal)
 	for i, day := range weekdayLabelsJP {
+		label := day
+		if hasTodayMarker && i == todayIdx {
+			label = "🟢" + day
+		}
 		b.WriteString(" ")
-		b.WriteString(padLeftDisplayWidth(day, numWidth))
+		b.WriteString(padLeftDisplayWidth(label, numWidth))
 		if i < len(weekdayLabelsJP)-1 {
 			b.WriteString(" |")
 		}
@@ -627,6 +633,17 @@ func RenderWeekBuffer(week WeekValues, areaNames []string, year, weekIndex int,
 		b.WriteString(rowStr + "\n")
 	}
 	return b.String()
+}
+
+func headerTodayMarkerDayIndex(year int, weekIndex int, nowLocal time.Time) (int, bool) {
+	if nowLocal.IsZero() {
+		return 0, false
+	}
+	nowYear, nowWeek := nowLocal.ISOWeek()
+	if nowYear != year || nowWeek != weekIndex+1 {
+		return 0, false
+	}
+	return WeekdayToDayIndex(nowLocal.Weekday()), true
 }
 
 // padRightDisplayWidth pads s to at least width display cells with spaces.
@@ -858,8 +875,10 @@ func WeekEdit(cfg StartCfg, woy WoY) error {
 	}
 	// 7. Compute week start (Monday of that ISO week)
 	weekStart := weekStartFor(woy.Year, woy.Week)
+	nowLocal := time.Now().In(time.Local)
 	// 8. Render buffer
-	buf := RenderWeekBuffer(*week, areaNames, woy.Year, woy.WeekIndex(), weekStart)
+	buf := RenderWeekBuffer(*week, areaNames, woy.Year, woy.WeekIndex(), weekStart,
+		nowLocal)
 	// 9. Create temp file, write buf
 	pattern := fmt.Sprintf("focustime-%dw%d_*", woy.Year, woy.Week)
 	tmp, err := os.CreateTemp("", pattern)

--- a/focustime/src/focustime_test.go
+++ b/focustime/src/focustime_test.go
@@ -20,6 +20,39 @@ type S struct {
 	suite.Suite
 }
 
+func (s *S) TestResolveStartCfgNoFileUsesChicago() {
+	newHome := s.T().TempDir()
+	s.T().Setenv("XDG_CONFIG_HOME", filepath.Join(newHome, "cfg"))
+	cfg, err := ResolveStartCfg(StartCfg{HomeDir: newHome})
+	s.NoError(err)
+	s.Equal("America/Chicago", cfg.Timezone)
+	s.NotNil(cfg.Loc)
+}
+
+func (s *S) TestResolveStartCfgInvalidConfigJSON() {
+	newHome := s.T().TempDir()
+	xdg := filepath.Join(newHome, "cfg")
+	s.T().Setenv("XDG_CONFIG_HOME", xdg)
+	s.NoError(os.MkdirAll(filepath.Join(xdg, "focustime"), 0o755))
+	path := filepath.Join(xdg, "focustime", "config.json")
+	s.NoError(os.WriteFile(path, []byte("{not json"), 0o644))
+	_, err := ResolveStartCfg(StartCfg{HomeDir: newHome})
+	s.Error(err)
+	s.Contains(err.Error(), "config file")
+}
+
+func (s *S) TestResolveStartCfgTimezoneFieldSkipsFile() {
+	newHome := s.T().TempDir()
+	xdg := filepath.Join(newHome, "cfg")
+	s.T().Setenv("XDG_CONFIG_HOME", xdg)
+	s.NoError(os.MkdirAll(filepath.Join(xdg, "focustime"), 0o755))
+	path := filepath.Join(xdg, "focustime", "config.json")
+	s.NoError(os.WriteFile(path, []byte(`{"timezone":"America/New_York"}`), 0o644))
+	cfg, err := ResolveStartCfg(StartCfg{HomeDir: newHome, Timezone: "UTC"})
+	s.NoError(err)
+	s.Equal("UTC", cfg.Timezone)
+}
+
 func (s *S) TestTimeToWeek() {
 	type TC struct {
 		t    time.Time
@@ -38,7 +71,7 @@ func (s *S) TestTimeToWeek() {
 		},
 	} {
 		s.Run(fmt.Sprintf("tc %d, %#v", tcIdx, tc), func() {
-			got := TimeToWoY(tc.t)
+			got := TimeToWoY(tc.t, time.UTC)
 			s.Equal(tc.want, got)
 		})
 	}
@@ -52,8 +85,9 @@ func (s *S) TestCreateFocusTimeDir() {
 		HomeDir: newHome,
 	}
 
-	ftDir := DirFTData(cfg)
-	_, err := os.Stat(ftDir)
+	ftDir, err := DirFTData(cfg)
+	s.NoError(err)
+	_, err = os.Stat(ftDir)
 	s.True(os.IsNotExist(err), "expect focustime data dir to not exist yet")
 
 	err = CreateFocusTimeDir(cfg)
@@ -69,8 +103,10 @@ func (s *S) TestLoadAreasFile() {
 	s.T().Setenv("XDG_DATA_HOME", newHome)
 	cfg := StartCfg{HomeDir: newHome}
 
-	areasPath := filepath.Join(DirFTData(cfg), "areas.json")
-	_, err := os.Stat(areasPath)
+	dir, err := DirFTData(cfg)
+	s.NoError(err)
+	areasPath := filepath.Join(dir, "areas.json")
+	_, err = os.Stat(areasPath)
 	s.True(os.IsNotExist(err), "areas.json should not exist yet")
 
 	got, err := LoadAreasFile(cfg)
@@ -97,7 +133,9 @@ func (s *S) TestSaveAreasFile() {
 	err := SaveAreasFile(cfg, reg)
 	s.NoError(err)
 
-	areasPath := filepath.Join(DirFTData(cfg), "areas.json")
+	dir, err := DirFTData(cfg)
+	s.NoError(err)
+	areasPath := filepath.Join(dir, "areas.json")
 	info, err := os.Stat(areasPath)
 	s.NoError(err)
 	s.False(info.IsDir(), "areas.json should be a file")
@@ -530,7 +568,7 @@ func (s *S) TestLogTime() {
 	s.Equal(45, logged)
 
 	now := time.Now().UTC()
-	woy := TimeToWoY(now)
+	woy := TimeToWoY(now, time.UTC)
 	yf, err := LoadYearFile(cfg, woy.Year)
 	s.NoError(err)
 	week := yf.Weeks[woy.WeekIndex()]
@@ -567,7 +605,7 @@ func (s *S) TestTodayReportNoWeekData() {
 	now := time.Date(2026, 3, 3, 12, 0, 0, 0, time.UTC)
 	out, err := TodayReport(cfg, now)
 	s.NoError(err)
-	s.Contains(out, "Today (2026-03-03, Tuesday): no data yet.")
+	s.Contains(out, "Today (2026-03-03, Tuesday, 12:00:00 UTC): no data yet.")
 }
 
 func (s *S) TestTodayReportWeekExistsButNoTodayData() {
@@ -583,7 +621,7 @@ func (s *S) TestTodayReportWeekExistsButNoTodayData() {
 	s.NoError(err)
 
 	now := time.Date(2026, 3, 3, 12, 0, 0, 0, time.UTC) // Tuesday
-	woy := TimeToWoY(now)
+	woy := TimeToWoY(now, time.UTC)
 	yf := emptyYearFile(woy.Year)
 	week := &WeekValues{
 		Areas: []int{0, 1, 2},
@@ -601,7 +639,7 @@ func (s *S) TestTodayReportWeekExistsButNoTodayData() {
 
 	out, err := TodayReport(cfg, now)
 	s.NoError(err)
-	s.Contains(out, "Today (2026-03-03, Tuesday)")
+	s.Contains(out, "Today (2026-03-03, Tuesday, 12:00:00 UTC)")
 	s.Contains(out, "No data logged for today.")
 }
 
@@ -618,7 +656,7 @@ func (s *S) TestTodayReportWithValuesAndTotal() {
 	s.NoError(err)
 
 	now := time.Date(2026, 3, 3, 12, 0, 0, 0, time.UTC) // Tuesday
-	woy := TimeToWoY(now)
+	woy := TimeToWoY(now, time.UTC)
 	yf := emptyYearFile(woy.Year)
 	week := &WeekValues{
 		Areas: []int{0, 1, 2},
@@ -638,7 +676,7 @@ func (s *S) TestTodayReportWithValuesAndTotal() {
 
 	out, err := TodayReport(cfg, now)
 	s.NoError(err)
-	s.Contains(out, "Today (2026-03-03, Tuesday)")
+	s.Contains(out, "Today (2026-03-03, Tuesday, 12:00:00 UTC)")
 	s.Contains(out, "0 → A: 30m")
 	s.Contains(out, "2 → C: 45m")
 	s.Contains(out, "Total: 75m")
@@ -675,7 +713,7 @@ func (s *S) TestCurrentWeekReportWithWeekData() {
 	s.NoError(err)
 
 	now := time.Date(2026, 3, 3, 12, 0, 0, 0, time.UTC)
-	woy := TimeToWoY(now)
+	woy := TimeToWoY(now, time.UTC)
 	yf := emptyYearFile(woy.Year)
 	week := &WeekValues{
 		Areas: []int{0, 1, 2},

--- a/focustime/src/focustime_test.go
+++ b/focustime/src/focustime_test.go
@@ -257,7 +257,8 @@ func (s *S) TestRenderWeekBuffer() {
 	got := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart)
 	s.Contains(got, "# focustime week view")
 	s.Contains(got, "# Week index: 2025w10 (Week starting: 2025-03-03)")
-	s.Contains(got, "# Columns: Area | Mon | Tue | Wed | Thu | Fri | Sat | Sun")
+	s.Contains(got, "# Area")
+	s.Contains(got, "|   日 |   月 |   火 |   水 |   木 |   金 |   土")
 	s.Contains(got, "Deep Work  |")
 	s.Contains(got, "120")
 	s.Contains(got, "90")
@@ -304,24 +305,43 @@ func (s *S) TestRenderWeekBufferAlignsUsingLongestAreaName() {
 	expectedAreaColWidth := runewidth.StringWidth("かなり長いエリア名です") + 1
 
 	var widths []int
+	var headerPipeWidths []int
+	var rowPipeWidths []int
+	pipeDisplayWidths := func(line string) []int {
+		widths := []int{}
+		for i := 0; i < len(line); i++ {
+			if line[i] == '|' {
+				widths = append(widths, runewidth.StringWidth(line[:i]))
+			}
+		}
+		return widths
+	}
 	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "# ") &&
+			strings.Contains(line, "|   日 |   月 |   火 |   水 |   木 |   金 |   土") {
+			headerPipeWidths = pipeDisplayWidths(line)
+		}
 		if strings.HasPrefix(line, "短い") ||
 			strings.HasPrefix(line, "かなり長いエリア名です") ||
 			strings.HasPrefix(line, "mid") {
 			left := strings.SplitN(line, "|", 2)[0]
 			widths = append(widths, runewidth.StringWidth(left))
+			if len(rowPipeWidths) == 0 {
+				rowPipeWidths = pipeDisplayWidths(line)
+			}
 		}
 	}
 	s.Len(widths, 3)
 	s.Equal(widths[0], widths[1])
 	s.Equal(widths[1], widths[2])
 	s.Equal(expectedAreaColWidth+1, widths[0]) // +1 for " " before "|"
+	s.Equal(rowPipeWidths, headerPipeWidths)
 }
 
 func (s *S) TestParseWeekBuffer() {
 	buf := `# focustime week view
 # Week index: 2025w10 (Week starting: 2025-03-03)
-# Columns: Area | Mon | Tue | Wed | Thu | Fri | Sat | Sun
+# Columns: Area | 日 | 月 | 火 | 水 | 木 | 金 | 土
 
 Deep Work | 120 |  90 |  60 |   0 |   0 |     |
 Coding    |  30 |  30 |  45 |     |   0 |     |
@@ -448,13 +468,13 @@ func (s *S) TestParseDurationToMinutes() {
 }
 
 func (s *S) TestWeekdayToDayIndex() {
-	s.Equal(0, WeekdayToDayIndex(time.Monday))
-	s.Equal(1, WeekdayToDayIndex(time.Tuesday))
-	s.Equal(2, WeekdayToDayIndex(time.Wednesday))
-	s.Equal(3, WeekdayToDayIndex(time.Thursday))
-	s.Equal(4, WeekdayToDayIndex(time.Friday))
-	s.Equal(5, WeekdayToDayIndex(time.Saturday))
-	s.Equal(6, WeekdayToDayIndex(time.Sunday))
+	s.Equal(0, WeekdayToDayIndex(time.Sunday))
+	s.Equal(1, WeekdayToDayIndex(time.Monday))
+	s.Equal(2, WeekdayToDayIndex(time.Tuesday))
+	s.Equal(3, WeekdayToDayIndex(time.Wednesday))
+	s.Equal(4, WeekdayToDayIndex(time.Thursday))
+	s.Equal(5, WeekdayToDayIndex(time.Friday))
+	s.Equal(6, WeekdayToDayIndex(time.Saturday))
 }
 
 func (s *S) TestLogTime() {
@@ -640,9 +660,9 @@ func (s *S) TestCurrentWeekReportWithWeekData() {
 	s.NoError(err)
 	s.Contains(out, "# focustime week view")
 	s.Contains(out, "# Week index:")
-	s.Contains(out, "A  |")
-	s.Contains(out, "B  |")
-	s.Contains(out, "C  |")
+	s.Contains(out, "A     |")
+	s.Contains(out, "B     |")
+	s.Contains(out, "C     |")
 	s.Contains(out, "50")
 }
 

--- a/focustime/src/focustime_test.go
+++ b/focustime/src/focustime_test.go
@@ -254,7 +254,7 @@ func (s *S) TestRenderWeekBuffer() {
 	}
 	areaNames := []string{"Deep Work", "Coding", "Exercise"}
 	weekStart := time.Date(2025, 3, 3, 0, 0, 0, 0, time.UTC)
-	got := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart)
+	got := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart, time.Time{})
 	s.Contains(got, "# focustime week view")
 	s.Contains(got, "# Week index: 2025w10 (Week starting: 2025-03-03)")
 	s.Contains(got, "# Area")
@@ -263,6 +263,42 @@ func (s *S) TestRenderWeekBuffer() {
 	s.Contains(got, "120")
 	s.Contains(got, "90")
 	s.Contains(got, "Exercise")
+}
+
+func (s *S) TestRenderWeekBufferMarksTodayColumnForMatchingWeek() {
+	week := WeekValues{
+		Areas: []int{0},
+		Values: [][]*int{
+			make([]*int, 7),
+		},
+	}
+	areaNames := []string{"Deep Work"}
+	// 2026-03-25 is Wednesday in JST; ISO week 13 of 2026.
+	jst := time.FixedZone("JST", 9*60*60)
+	nowLocal := time.Date(2026, 3, 25, 12, 0, 0, 0, jst)
+	year, weekNum := nowLocal.ISOWeek()
+	weekStart := weekStartFor(year, weekNum)
+	got := RenderWeekBuffer(week, areaNames, year, weekNum-1, weekStart, nowLocal)
+
+	s.Contains(got, "🟢水")
+	s.Equal(1, strings.Count(got, "🟢"))
+	// Marker replaces one left-padding space without shifting separators.
+	s.Contains(got, "|   日 |   月 |   火 | 🟢水 |   木 |   金 |   土")
+}
+
+func (s *S) TestRenderWeekBufferNoTodayMarkerForNonCurrentWeek() {
+	week := WeekValues{
+		Areas: []int{0},
+		Values: [][]*int{
+			make([]*int, 7),
+		},
+	}
+	areaNames := []string{"Deep Work"}
+	nowLocal := time.Date(2026, 3, 25, 12, 0, 0, 0, time.FixedZone("JST", 9*60*60))
+	weekStart := weekStartFor(2026, 12)
+	got := RenderWeekBuffer(week, areaNames, 2026, 11, weekStart, nowLocal)
+
+	s.NotContains(got, "🟢")
 }
 
 func (s *S) TestRenderWeekBufferFixedAreaColumnWidth() {
@@ -275,7 +311,7 @@ func (s *S) TestRenderWeekBufferFixedAreaColumnWidth() {
 	}
 	areaNames := []string{"A", "運動"}
 	weekStart := time.Date(2025, 3, 3, 0, 0, 0, 0, time.UTC)
-	got := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart)
+	got := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart, time.Time{})
 	expectedWidth := runewidth.StringWidth("運動") + 1
 
 	for _, line := range strings.Split(got, "\n") {
@@ -301,7 +337,7 @@ func (s *S) TestRenderWeekBufferAlignsUsingLongestAreaName() {
 		"mid",
 	}
 	weekStart := time.Date(2025, 3, 3, 0, 0, 0, 0, time.UTC)
-	got := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart)
+	got := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart, time.Time{})
 	expectedAreaColWidth := runewidth.StringWidth("かなり長いエリア名です") + 1
 
 	var widths []int
@@ -387,7 +423,7 @@ func (s *S) TestRenderParseRoundtrip() {
 	}
 	areaNames := []string{"Deep Work", "Coding", "Exercise"}
 	weekStart := time.Date(2025, 3, 3, 0, 0, 0, 0, time.UTC)
-	buf := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart)
+	buf := RenderWeekBuffer(week, areaNames, 2025, 9, weekStart, time.Time{})
 	parsed, err := ParseWeekBuffer([]byte(buf), areaNames, week.Areas)
 	s.NoError(err)
 	s.Equal(week.Areas, parsed.Areas)


### PR DESCRIPTION
# Focustime: configurable timezone, Japanese weekday labels, and clearer week UI

This change makes **week boundaries and "today"** follow a **user-chosen IANA timezone** (persisted under XDG) instead of implicit UTC, adds **`focustime config`** to inspect and edit that setting safely, and tightens **week table readability** with **Japanese single-kanji weekday headers** plus a **"today" marker** in the week editor so you can orient yourself without cross-checking the calendar.

## Key changes
- **Timezone and config file** — `StartCfg` now carries timezone and a resolved `*time.Location`. On startup, `ResolveStartCfg` loads `XDG_CONFIG_HOME/focustime/config.json` (creating the effective default **America/Chicago** when the file is missing), validates the zone, and propagates it through logging, ISO week calculation, `today` / `week` reports, and default `edit` week selection. Optional `HomeDir` defers to `os.UserHomeDir`; XDG path helpers return errors when home resolution fails instead of silently using an empty path.
- **CLI** — New `focustime config` prints merged effective JSON; `focustime config edit` opens `$EDITOR` and only persists valid JSON and a loadable timezone. `today` / `week` pass wall-clock `time.Now()` into reports so conversion happens in one place using `cfg.Location()`.
- **Week grid and editor** — Week views use **日・月・火・水・木・金・土** column labels (Sunday-first ordering preserved). The week **edit** buffer highlights which column is "today" for quicker scanning.
- **Tests** — CLI and package tests seed XDG config where needed, cover `ResolveStartCfg` (default, bad JSON, caller override), config show/edit behavior, and updated expectations for timezone-aware output and headers.

## Appendix
- **Branch:** `ud/focustime` (diff vs `main`: `focustime/main.go`, `focustime/src/cli.go`, `focustime/src/cli_test.go`, `focustime/src/focustime.go`, `focustime/src/focustime_test.go`).
- **Upgrade note:** Existing installs without `config.json` pick up the Chicago default on first run; set `timezone` via `focustime config edit` or by editing the JSON if you need a different zone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dates/weeks are computed and persisted by introducing a timezone-aware config file and updating day/week indexing, which could affect existing data interpretation and reporting output.
> 
> **Overview**
> Adds a user-editable JSON config (under XDG config) to persist an IANA `timezone`, resolves it at startup via `ResolveStartCfg`, and updates `today`/`week`/`edit`/`log` flows to compute ISO weeks and “today” using the configured `Location()` instead of implicit UTC.
> 
> Introduces `focustime config` (show effective config) and `focustime config edit` (open `$EDITOR`, validate JSON/timezone, atomic write), tightens XDG path helpers to return errors, and refreshes the week UI with Japanese weekday headers plus a “today” column marker and updated alignment/labels. Tests are expanded/updated to cover config resolution/editing and the new timezone-aware outputs and rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82f0cf74664f60d03849a8099708e08d2df7f63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->