### PR TITLE
epic: ai-skills to share with team

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 | Path | Description |
 | ---- | ----------- |
+| <span style="white-space: nowrap;">📂 [ai-skills](./ai-skills/)</span> | Cursor/LLM agent skills for recurring workflows, repo navigation, PRs, chain queries, and data lookups |
 | <span style="white-space: nowrap;">📂 [algos](./algos/algos-notes.md)</span> | Algorithm practice problems with Go implementations and Anki-formatted notes for deliberate practice |
 | <span style="white-space: nowrap;">📂 [ctxcat](./ctxcat/README.md)</span> | File to context convertor for pasing files to feed LLMs. Similar to `cat` and `bat`. |
 | <span style="white-space: nowrap;">📂 [gocovmerge](./gocovmerge/README.md)</span> | Go coverage profile merger with modern CLI features |
@@ -17,6 +18,24 @@
 | <span style="white-space: nowrap;">📦 scripts</span> | Scripts crate in Rust |
 | <span style="white-space: nowrap;">├── justfile</span> | Runs project-specific commands |
 <!-- | <span style="white-space: nowrap;">└── README.md</span>  | ... | -->
+
+## `ai-skills`
+
+`ai-skills/` contains reusable agent skills for Cursor/LLM workflows. Each
+skill is a small, task-focused directory with a `SKILL.md` entrypoint and, when
+needed, supporting docs like `reference.md`, `REFERENCE.md`, `examples.md`, or
+schema notes.
+
+Current skills cover workflows such as:
+
+- writing commit messages and PR summaries
+- routing work across related repos
+- querying Nibiru via `nibid` or EVM RPC
+- querying indexer, Sai GraphQL, REST, and Postgres-backed data sources
+- checking governance proposals and upgrade status
+
+In practice, this directory is the repo's library of operational playbooks for
+repeatable AI-assisted tasks.
 
 ## Hacking
 

--- a/ai-skills/bash-defensive-patterns/SKILL.md
+++ b/ai-skills/bash-defensive-patterns/SKILL.md
@@ -1,0 +1,533 @@
+---
+name: bash-defensive-patterns
+description: Master defensive Bash programming techniques for production-grade scripts. Use when writing robust shell scripts, CI/CD pipelines, or system utilities requiring fault tolerance and safety.
+---
+
+# Bash Defensive Patterns
+
+Comprehensive guidance for writing production-ready Bash scripts using defensive programming techniques, error handling, and safety best practices to prevent common pitfalls and ensure reliability.
+
+## When to Use This Skill
+
+- Writing production automation scripts
+- Building CI/CD pipeline scripts
+- Creating system administration utilities
+- Developing error-resilient deployment automation
+- Writing scripts that must handle edge cases safely
+- Building maintainable shell script libraries
+- Implementing comprehensive logging and monitoring
+- Creating scripts that must work across different platforms
+
+## Core Defensive Principles
+
+### 1. Strict Mode
+
+Enable bash strict mode at the start of every script to catch errors early.
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail  # Exit on error, unset variables, pipe failures
+```
+
+**Key flags:**
+
+- `set -E`: Inherit ERR trap in functions
+- `set -e`: Exit on any error (command returns non-zero)
+- `set -u`: Exit on undefined variable reference
+- `set -o pipefail`: Pipe fails if any command fails (not just last)
+
+### 2. Error Trapping and Cleanup
+
+Implement proper cleanup on script exit or error.
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+trap 'echo "Error on line $LINENO"' ERR
+trap 'echo "Cleaning up..."; rm -rf "$TMPDIR"' EXIT
+
+TMPDIR=$(mktemp -d)
+# Script code here
+```
+
+### 3. Variable Safety
+
+Always quote variables to prevent word splitting and globbing issues.
+
+```bash
+# Wrong - unsafe
+cp $source $dest
+
+# Correct - safe
+cp "$source" "$dest"
+
+# Required variables - fail with message if unset
+: "${REQUIRED_VAR:?REQUIRED_VAR is not set}"
+```
+
+### 4. Array Handling
+
+Use arrays safely for complex data handling.
+
+```bash
+# Safe array iteration
+declare -a items=("item 1" "item 2" "item 3")
+
+for item in "${items[@]}"; do
+    echo "Processing: $item"
+done
+
+# Reading output into array safely
+mapfile -t lines < <(some_command)
+readarray -t numbers < <(seq 1 10)
+```
+
+### 5. Conditional Safety
+
+Use `[[ ]]` for Bash-specific features, `[ ]` for POSIX.
+
+```bash
+# Bash - safer
+if [[ -f "$file" && -r "$file" ]]; then
+    content=$(<"$file")
+fi
+
+# POSIX - portable
+if [ -f "$file" ] && [ -r "$file" ]; then
+    content=$(cat "$file")
+fi
+
+# Test for existence before operations
+if [[ -z "${VAR:-}" ]]; then
+    echo "VAR is not set or is empty"
+fi
+```
+
+## Fundamental Patterns
+
+### Pattern 1: Safe Script Directory Detection
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Correctly determine script directory
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+SCRIPT_NAME="$(basename -- "${BASH_SOURCE[0]}")"
+
+echo "Script location: $SCRIPT_DIR/$SCRIPT_NAME"
+```
+
+### Pattern 2: Comprehensive Function Templat
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Prefix for functions: handle_*, process_*, check_*, validate_*
+# Include documentation and error handling
+
+validate_file() {
+    local -r file="$1"
+    local -r message="${2:-File not found: $file}"
+
+    if [[ ! -f "$file" ]]; then
+        echo "ERROR: $message" >&2
+        return 1
+    fi
+    return 0
+}
+
+process_files() {
+    local -r input_dir="$1"
+    local -r output_dir="$2"
+
+    # Validate inputs
+    [[ -d "$input_dir" ]] || { echo "ERROR: input_dir not a directory" >&2; return 1; }
+
+    # Create output directory if needed
+    mkdir -p "$output_dir" || { echo "ERROR: Cannot create output_dir" >&2; return 1; }
+
+    # Process files safely
+    while IFS= read -r -d '' file; do
+        echo "Processing: $file"
+        # Do work
+    done < <(find "$input_dir" -maxdepth 1 -type f -print0)
+
+    return 0
+}
+```
+
+### Pattern 3: Safe Temporary File Handling
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+trap 'rm -rf -- "$TMPDIR"' EXIT
+
+# Create temporary directory
+TMPDIR=$(mktemp -d) || { echo "ERROR: Failed to create temp directory" >&2; exit 1; }
+
+# Create temporary files in directory
+TMPFILE1="$TMPDIR/temp1.txt"
+TMPFILE2="$TMPDIR/temp2.txt"
+
+# Use temporary files
+touch "$TMPFILE1" "$TMPFILE2"
+
+echo "Temp files created in: $TMPDIR"
+```
+
+### Pattern 4: Robust Argument Parsing
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Default values
+VERBOSE=false
+DRY_RUN=false
+OUTPUT_FILE=""
+THREADS=4
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+    -v, --verbose       Enable verbose output
+    -d, --dry-run       Run without making changes
+    -o, --output FILE   Output file path
+    -j, --jobs NUM      Number of parallel jobs
+    -h, --help          Show this help message
+EOF
+    exit "${1:-0}"
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -d|--dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -o|--output)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        -j|--jobs)
+            THREADS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "ERROR: Unknown option: $1" >&2
+            usage 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+[[ -n "$OUTPUT_FILE" ]] || { echo "ERROR: -o/--output is required" >&2; usage 1; }
+```
+
+### Pattern 5: Structured Logging
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Logging functions
+log_info() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] INFO: $*" >&2
+}
+
+log_warn() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] WARN: $*" >&2
+}
+
+log_error() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2
+}
+
+log_debug() {
+    if [[ "${DEBUG:-0}" == "1" ]]; then
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] DEBUG: $*" >&2
+    fi
+}
+
+# Usage
+log_info "Starting script"
+log_debug "Debug information"
+log_warn "Warning message"
+log_error "Error occurred"
+```
+
+### Pattern 6: Process Orchestration with Signals
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Track background processes
+PIDS=()
+
+cleanup() {
+    log_info "Shutting down..."
+
+    # Terminate all background processes
+    for pid in "${PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null || true
+        fi
+    done
+
+    # Wait for graceful shutdown
+    for pid in "${PIDS[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Start background tasks
+background_task &
+PIDS+=($!)
+
+another_task &
+PIDS+=($!)
+
+# Wait for all background processes
+wait
+```
+
+### Pattern 7: Safe File Operations
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Use -i flag to move safely without overwriting
+safe_move() {
+    local -r source="$1"
+    local -r dest="$2"
+
+    if [[ ! -e "$source" ]]; then
+        echo "ERROR: Source does not exist: $source" >&2
+        return 1
+    fi
+
+    if [[ -e "$dest" ]]; then
+        echo "ERROR: Destination already exists: $dest" >&2
+        return 1
+    fi
+
+    mv "$source" "$dest"
+}
+
+# Safe directory cleanup
+safe_rmdir() {
+    local -r dir="$1"
+
+    if [[ ! -d "$dir" ]]; then
+        echo "ERROR: Not a directory: $dir" >&2
+        return 1
+    fi
+
+    # Use -I flag to prompt before rm (BSD/GNU compatible)
+    rm -rI -- "$dir"
+}
+
+# Atomic file writes
+atomic_write() {
+    local -r target="$1"
+    local -r tmpfile
+    tmpfile=$(mktemp) || return 1
+
+    # Write to temp file first
+    cat > "$tmpfile"
+
+    # Atomic rename
+    mv "$tmpfile" "$target"
+}
+```
+
+### Pattern 8: Idempotent Script Design
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Check if resource already exists
+ensure_directory() {
+    local -r dir="$1"
+
+    if [[ -d "$dir" ]]; then
+        log_info "Directory already exists: $dir"
+        return 0
+    fi
+
+    mkdir -p "$dir" || {
+        log_error "Failed to create directory: $dir"
+        return 1
+    }
+
+    log_info "Created directory: $dir"
+}
+
+# Ensure configuration state
+ensure_config() {
+    local -r config_file="$1"
+    local -r default_value="$2"
+
+    if [[ ! -f "$config_file" ]]; then
+        echo "$default_value" > "$config_file"
+        log_info "Created config: $config_file"
+    fi
+}
+
+# Rerunning script multiple times should be safe
+ensure_directory "/var/cache/myapp"
+ensure_config "/etc/myapp/config" "DEBUG=false"
+```
+
+### Pattern 9: Safe Command Substitution
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+# Use $() instead of backticks
+name=$(<"$file")  # Modern, safe variable assignment from file
+output=$(command -v python3)  # Get command location safely
+
+# Handle command substitution with error checking
+result=$(command -v node) || {
+    log_error "node command not found"
+    return 1
+}
+
+# For multiple lines
+mapfile -t lines < <(grep "pattern" "$file")
+
+# NUL-safe iteration
+while IFS= read -r -d '' file; do
+    echo "Processing: $file"
+done < <(find /path -type f -print0)
+```
+
+### Pattern 10: Dry-Run Support
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+DRY_RUN="${DRY_RUN:-false}"
+
+run_cmd() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[DRY RUN] Would execute: $*"
+        return 0
+    fi
+
+    "$@"
+}
+
+# Usage
+run_cmd cp "$source" "$dest"
+run_cmd rm "$file"
+run_cmd chown "$owner" "$target"
+```
+
+## Advanced Defensive Techniques
+
+### Named Parameters Pattern
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+process_data() {
+    local input_file=""
+    local output_dir=""
+    local format="json"
+
+    # Parse named parameters
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --input=*)
+                input_file="${1#*=}"
+                ;;
+            --output=*)
+                output_dir="${1#*=}"
+                ;;
+            --format=*)
+                format="${1#*=}"
+                ;;
+            *)
+                echo "ERROR: Unknown parameter: $1" >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    # Validate required parameters
+    [[ -n "$input_file" ]] || { echo "ERROR: --input is required" >&2; return 1; }
+    [[ -n "$output_dir" ]] || { echo "ERROR: --output is required" >&2; return 1; }
+}
+```
+
+### Dependency Checking
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+check_dependencies() {
+    local -a missing_deps=()
+    local -a required=("jq" "curl" "git")
+
+    for cmd in "${required[@]}"; do
+        if ! command -v "$cmd" &>/dev/null; then
+            missing_deps+=("$cmd")
+        fi
+    done
+
+    if [[ ${#missing_deps[@]} -gt 0 ]]; then
+        echo "ERROR: Missing required commands: ${missing_deps[*]}" >&2
+        return 1
+    fi
+}
+
+check_dependencies
+```
+
+## Best Practices Summary
+
+1. **Always use strict mode** - `set -Eeuo pipefail`
+2. **Quote all variables** - `"$variable"` prevents word splitting
+3. **Use [[]] conditionals** - More robust than [ ]
+4. **Implement error trapping** - Catch and handle errors gracefully
+5. **Validate all inputs** - Check file existence, permissions, formats
+6. **Use functions for reusability** - Prefix with meaningful names
+7. **Implement structured logging** - Include timestamps and levels
+8. **Support dry-run mode** - Allow users to preview changes
+9. **Handle temporary files safely** - Use mktemp, cleanup with trap
+10. **Design for idempotency** - Scripts should be safe to rerun
+11. **Document requirements** - List dependencies and minimum versions
+12. **Test error paths** - Ensure error handling works correctly
+13. **Use `command -v`** - Safer than `which` for checking executables
+14. **Prefer printf over echo** - More predictable across systems

--- a/ai-skills/commit-diff/SKILL.md
+++ b/ai-skills/commit-diff/SKILL.md
@@ -42,32 +42,36 @@ Output **one subject line**, plus an optional body when it helps explain "why".
 
 Subject format:
 
-`type(scope): imperative summary`
+`type(scope): Imperative summary`
 
 - **type**: prefer one of `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`
-- **scope**: optional, short (e.g. `sai`, `indexer`, `scripts`, `docs`)
-- **imperative**: "add", "fix", "remove", "refactor" (not past tense)
-- **length**: keep subject <= 72 chars; no trailing period
-- **breaking changes**: add `!` after type/scope when clearly breaking (`feat!: …`, `feat(api)!: …`)
+- **scope**: Optional, short (e.g. `sai`, `indexer`, `scripts`, `docs`)
+- **imperative** (subject): "Add", "Fix", "Remove", "Refactor" (not past tense)
+- **length**: Keep subject <= 80 chars. No trailing period
+- **breaking changes**: Add `!` after type/scope when clearly breaking (`feat!: …`, `feat(api)!: …`)
 
 Body (optional):
 
 - Blank line after subject
 - 1–3 bullets focusing on **why** and any non-obvious behavior changes
+- Be clear, cogent, concise.
 
 ### Examples
 
+- Break "conventional commit" pattern slightly to use this preferred format,
+where the summary is capitalized.
+
 ```
-feat(sai): add vault OI query helpers
+feat(sai): Add vault OI query helpers
 ```
 
 ```
-fix(indexer): query staking data via staking container
+fix(indexer): Query staking data via staking container
 
 - Avoid deprecated root-level fields
 - Clarify amount units (unibi) in output
 ```
 
 ```
-chore(scripts): align tx query output formatting
+chore(scripts): Align tx query output format
 ```

--- a/ai-skills/drill-spec/SKILL.md
+++ b/ai-skills/drill-spec/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: drill-spec
+description: Interview the user relentlessly about a plan, spec, or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "drill the spec" or "drill the plan".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/ai-skills/epics-plus/SKILL.md
+++ b/ai-skills/epics-plus/SKILL.md
@@ -16,7 +16,7 @@ Navigate, interpret, and manage Epics+ docs in the boku repository. Use this ski
    ```
 3. **Verify/Scan**: To see all epics with frontmatter or validate them:
    ```bash
-   cd /home/realu/ki/boku/epics && just epics-plus scan --only-with-frontmatter --strict
+   cd /home/realu/ki/boku/epics && just epics-plus scan --fm-only --strict
    ```
 
 ## Interpreting Epics+ Frontmatter (Reader View)
@@ -53,7 +53,7 @@ Run from `/home/realu/ki/boku/epics`:
   - `--dry-run`: Print to stdout instead.
   - `--all-statuses`: Include inactive/done/archived epics.
 - `just epics-plus scan`: List epics.
-  - `--only-with-frontmatter`: Skip files without Epics+ YAML.
+  - `--fm-only`: Skip files without Epics+ YAML.
   - `--strict`: Exit non-zero if validation fails.
   - `--format ndjson`: Useful for batch processing.
 

--- a/ai-skills/find-skills/SKILL.md
+++ b/ai-skills/find-skills/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/ai-skills/justfile/SKILL.md
+++ b/ai-skills/justfile/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: just
+description: >-
+  Prefer the nearest relevant `justfile` as the default command surface for
+  build, test, lint, format, run, deploy, and repo automation workflows. Use
+  when a repo or subproject has a `justfile`, or when the user mentions `just`,
+  `justfile`, recipes, or Makefile-to-just migration.
+---
+
+# Just
+
+Use this skill when a repo may expose commands through `justfile`.
+
+Treat `just` as the canonical task interface when it exists. Prefer existing
+recipes over reconstructing the underlying `go`, `npm`, `cargo`, `docker`,
+`make`, or shell commands by hand.
+
+## When To Use This Skill
+
+Use it when:
+
+- the repo or a nearby subproject has a `justfile`
+- the user asks how to build, test, lint, run, deploy, or inspect commands
+- the user mentions `just`, `justfile`, recipes, or recipe arguments
+- the repo has both `Makefile` and `justfile` and you need to understand which
+  command surface is intended
+- the user wants to migrate from `make` to `just`
+
+## Default Workflow
+
+1. Find the nearest relevant `justfile`. Do not assume repo root.
+2. Run `just --list` in that directory to discover the supported UX.
+3. If a recipe is unclear, inspect it with `just --show <recipe>`.
+4. Use the recipe directly unless the user explicitly wants the raw command.
+5. Fall back to ad hoc commands only when no suitable recipe exists.
+
+Common recipe names to check first: `setup`, `install`, `build`, `test`, `lint`,
+`fmt`, `dev`, `run`, `preview`, `deploy`.
+
+## Agent Guardrails
+
+- Prefer the nearest task-specific `justfile` over a broader root-level one.
+- If both `Makefile` and `justfile` exist, inspect both before suggesting
+  migration or replacement.
+- Do not bypass an existing recipe unless it is missing, clearly wrong for the
+  task, or the user asks for the underlying command.
+- Do not assume `.env` exists, and do not print secrets just because a
+  `justfile` uses `dotenv-load` or exported variables.
+- Treat destructive or confirmation-gated recipes cautiously.
+
+## Common Failure Modes
+
+### Wrong Working Directory
+
+Nested `justfile`s are common. If commands look wrong, verify you are running in
+the correct subproject. When needed, invoke a specific file directly with
+`just --justfile path/to/justfile <recipe>` instead of guessing.
+
+### Sparse Or Misleading `--list` Output
+
+Some repos split recipes across imported files or modules. If `just --list`
+looks too small, inspect the `justfile` for `import` or `mod` statements before
+assuming recipes are missing.
+
+### Hidden Helper Recipes
+
+`[private]` recipes do not appear in `just --list` or `just --summary`, so they
+do not pollute help output. They are still valid recipe entry points and can be
+invoked directly with `just <private-recipe>` when an internal workflow, CI job,
+or explicit user request needs them. Check `just --show <recipe>`, use
+`just --dry-run <recipe>`, or inspect the file if a public recipe depends on
+helpers you cannot see in the listing.
+
+### Env Or Shell Drift
+
+Behavior can change based on settings such as:
+
+- `set dotenv-load`
+- `set export`
+- `set shell := [...]`
+- `set positional-arguments`
+
+If a recipe works differently in CI, in a subdirectory, or in the terminal,
+check these settings before changing the command.
+
+### Confirmation Gates
+
+Recipes marked with `[confirm]` may block or fail in non-interactive contexts.
+Treat them as intentional safety rails, especially for `destroy`, `clean`, or
+production deploy flows.
+
+## Quick Command Reference
+
+- `just --list` list public recipes with descriptions
+- `just --show <recipe>` show the resolved recipe body
+- `just --summary` list recipe names only
+- `just --dry-run <recipe>` print commands without executing them, including
+  private recipes
+- `just --dump` print the full justfile
+- `just --evaluate` inspect variable evaluation
+- `just <recipe> [args...]` run a recipe
+- `just --justfile path/to/justfile <recipe>` target a specific justfile
+
+## Notes
+
+- Comments above recipes become descriptions in `just --list`.
+- Each recipe line runs in a separate shell unless the recipe is a shebang
+  script.
+- Large repos may use `just` as a command hub over other toolchains rather than
+  exposing the toolchain directly.
+
+## References
+
+- [references/make-migration.md](references/make-migration.md)
+- [references/justfile-patterns.md](references/justfile-patterns.md)

--- a/ai-skills/justfile/references/justfile-patterns.md
+++ b/ai-skills/justfile/references/justfile-patterns.md
@@ -1,0 +1,121 @@
+# Justfile Patterns
+
+Use this as a reference for common `justfile` patterns. Keep examples small and
+non-prescriptive. Prefer the repo's existing recipes over copying templates.
+
+## Core Settings
+
+```just
+set dotenv-load
+set shell := ["bash", "-euco", "pipefail"]
+set export
+```
+
+- `dotenv-load` explains implicit env loading from `.env`
+- `shell` explains fail-fast behavior and shell-specific syntax
+- `export` makes `just` variables available to recipe commands
+
+## Default Help Pattern
+
+```just
+[private]
+default:
+    @just --list --unsorted
+```
+
+Use this when the repo wants `just` with no arguments to behave like help.
+
+## Parameterized Recipe
+
+```just
+deploy env:
+    ./scripts/deploy {{env}}
+```
+
+Use recipe arguments instead of hardcoding environment names or resources.
+
+## Variadic Recipe
+
+```just
+test *args:
+    uv run pytest {{args}}
+```
+
+Useful when the underlying tool already has a stable CLI and the recipe mostly
+adds project defaults.
+
+## Shebang Recipe
+
+```just
+check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for cmd in jq rg just; do
+        command -v "$cmd" >/dev/null || { echo "Missing: $cmd"; exit 1; }
+    done
+```
+
+Use shebang recipes when multiple lines must share shell state.
+
+## Hidden Helper Recipe
+
+```just
+[private]
+_ensure-tools:
+    #!/usr/bin/env bash
+    command -v terraform >/dev/null
+
+plan: _ensure-tools
+    terraform plan
+```
+
+Remember that `[private]` helpers will not appear in `just --list`.
+
+## Confirmation Gate
+
+```just
+[confirm("Destroy all resources?")]
+destroy:
+    terraform destroy
+```
+
+Use for destructive operations. Agents should treat these as intentional safety
+rails rather than friction to bypass.
+
+## Grouped Recipes
+
+```just
+[group("ci")]
+ci-test:
+    cargo test
+
+[group("deploy")]
+deploy-prod:
+    ./deploy production
+```
+
+Helpful when `just --list` doubles as the repo's command menu.
+
+## Imports And Modules
+
+```just
+import "ci.just"
+mod deploy "deploy.just"
+```
+
+- `import` pulls in recipes from another file
+- `mod` namespaces recipes, for example `just deploy::prod`
+
+If a recipe seems missing, inspect the main `justfile` for `import` or `mod`
+before assuming the command surface is incomplete.
+
+## Project-Type Hints
+
+Use these as discovery hints, not templates:
+
+- Go repos often expose `build`, `test`, `lint`, `fmt`, and release helpers.
+- Python repos often expose `install`, `test`, `lint`, `fmt`, and `typecheck`.
+- Infra repos often expose `init`, `plan`, `apply`, `destroy`, and validation.
+- Docker-heavy repos often expose image build/push recipes plus local run flows.
+
+For all of them, prefer `just --list` and `just --show` over guessing.

--- a/ai-skills/justfile/references/make-migration.md
+++ b/ai-skills/justfile/references/make-migration.md
@@ -1,0 +1,91 @@
+# Makefile To Justfile Migration
+
+Use this when a repo has both `Makefile` and `justfile`, or when the user wants
+to migrate commands from `make` to `just`.
+
+## Fast Mapping
+
+| Make | Just | Notes |
+| --- | --- | --- |
+| `.PHONY: target` | not needed | `just` does not track file timestamps |
+| `.DEFAULT_GOAL := help` | put the default recipe first or use `[default]` | first public recipe is the default |
+| `target: dep1 dep2` | `target: dep1 dep2` | dependency syntax is similar |
+| `@command` | `@command` | suppress command echo |
+| `$(VAR)` / `${VAR}` | `{{var}}` | `just` interpolation |
+| `$$VAR` | `$VAR` | shell vars do not use double-dollar escaping |
+| `VAR := value` | `var := "value"` | quote strings in `just` |
+| `VAR ?= default` | `var := env('VAR', 'default')` | env fallback pattern |
+| `$(shell cmd)` | `` `cmd` `` | capture command output |
+| `export VAR := value` | `export var := "value"` or `set export` | export explicitly or globally |
+| `include file.mk` | `import 'file.just'` | import another file |
+
+## Differences That Matter
+
+### Shell Variables
+
+In `make`, literal shell variables use `$$`. In `just`, use `$` directly.
+
+```make
+target:
+	echo $$HOME
+```
+
+```just
+target:
+	echo $HOME
+```
+
+### Recipe Execution Model
+
+Like `make`, each line runs in a separate shell. Use a shebang recipe when the
+body must run as one script.
+
+```just
+check:
+    #!/usr/bin/env bash
+    if [ -f .env ]; then
+        echo "found"
+    fi
+```
+
+### Documentation
+
+`make` often needs a custom help target. In `just`, comments above recipes are
+already used by `just --list`.
+
+```just
+[private]
+default:
+    @just --list --unsorted
+
+# Run unit tests
+test:
+    cargo test
+```
+
+### Arguments
+
+`just` supports recipe arguments directly.
+
+```just
+recreate resource:
+    terraform apply -replace "{{resource}}"
+```
+
+## Migration Checklist
+
+1. Read the existing `Makefile` before rewriting anything.
+2. Keep both files during migration if the repo still depends on `make`.
+3. Convert variables, then recipes, then dependencies.
+4. Replace `$$` shell variables with `$`.
+5. Use comments above recipes so `just --list` stays useful.
+6. Add `[confirm]` to destructive recipes if the old flow relied on manual care.
+7. Verify migrated commands with `just --show <recipe>` and targeted dry runs.
+
+## Agent Guardrails
+
+- Do not suggest migration until you confirm the repo is using `just` as a real
+  command surface rather than as an experiment.
+- Watch for make-specific behavior that may not carry over cleanly, such as
+  pattern rules, file-based dependency graphs, or job parallelism.
+- If both files exist, prefer the one the repo actually documents and uses.

--- a/ai-skills/lang-cavemen/SKILL.md
+++ b/ai-skills/lang-cavemen/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lang-caveman
+description: >-
+  Ultra-compressed communication mode. Cuts token usage ~75% by dropping
+  filler, articles, and pleasantries while keeping full technical accuracy.
+  Use when user says "caveman mode", "talk like caveman", "use caveman language",
+  "less tokens", "be brief", or invokes /lang-caveman.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE once triggered. No revert after many turns. No filler
+drift. Still active if unsure. Off only when user says "stop caveman" or "normal
+mode".
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply),
+pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short
+synonyms (big not extensive, fix not "implement a solution for"). Abbreviate
+common terms (DB/auth/config/req/res/fn/impl). Strip conjunctions. Use arrows for
+causality (X -> Y). One word when one word enough.
+
+Technical terms stay exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+### Examples
+
+**"Why React component re-render?"**
+
+> Inline obj prop -> new ref -> re-render. `useMemo`.
+
+**"Explain database connection pooling."**
+
+> Pool = reuse DB conn. Skip handshake -> fast under load.
+
+## Auto-Clarity Exception
+
+Drop caveman temporarily for: security warnings, irreversible action
+confirmations, multi-step sequences where fragment order risks misread, user asks
+to clarify or repeats question. Resume caveman after clear part done.
+
+Example -- destructive op:
+
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+>
+> ```sql
+> DROP TABLE users;
+> ```
+>
+> Caveman resume. Verify backup exist first.

--- a/ai-skills/new-chat-prompt/SKILL.md
+++ b/ai-skills/new-chat-prompt/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: new-chat-prompt
+description: Writes a ready-to-paste prompt for a fresh chat instead of completing the requested task directly. Use when the user asks to start a new chat, move work to a new chat, or says to write a prompt for tackling the task elsewhere.
+---
+
+# New Chat Prompt
+
+When this skill applies, do not complete the underlying task.
+
+Instead, write a concise prompt the user can paste into a new chat where the task will be handled there.
+
+Include:
+- The user's goal
+- Any important context already known
+- Clear instructions for the next agent
+
+Keep the prompt self-contained and avoid extra explanation unless the user asks for it.

--- a/ai-skills/nibiru-cli-nibid/SKILL.md
+++ b/ai-skills/nibiru-cli-nibid/SKILL.md
@@ -162,6 +162,27 @@ Rules of thumb:
 - Reuse a known-good query message shape from the relevant repo or skill when
   the exact message is not obvious.
 
+#### Discover query variants without source
+
+If you do not have the contract source or schema, probe with an unknown query
+key. Many CosmWasm contracts return a serde enum error listing the accepted
+query enum variants.
+
+```bash
+CONTRACT_ADDR="nibi1..."
+nibid q wasm contract-state smart "$CONTRACT_ADDR" \
+  '{"_key_probe":{}}'
+```
+
+Example error:
+
+```text
+unknown variant `_key_probe`, expected one of `config`, `state`, ...
+```
+
+This is a discovery hint, not a full schema; enum variants may still need
+required fields.
+
 ### Tx Wasm
 
 ```bash

--- a/ai-skills/sai-db/schema.md
+++ b/ai-skills/sai-db/schema.md
@@ -1,6 +1,7 @@
 # Sai DB Schema Reference
 
-This document provides a detailed breakdown of the tables and types in the `sai-keeper` database.
+This document provides a detailed breakdown of the tables and types in the
+`sai-keeper` database.
 
 ## 1. Common (001_common.sql)
 
@@ -80,44 +81,59 @@ This document provides a detailed breakdown of the tables and types in the `sai-
   - `acc_fees_long`, `acc_fees_short`: float8
   - `oi_long`, `oi_short`, `oi_max`: bigint
   - `fee_per_block`, `fee_exponent`: float8
-  - `acc_last_updated_block`, `last_updated_block`, `last_updated_tx_index`, `last_updated_event_index`: bigint
-- **perp_borrowing**: Borrowing rate metrics for a specific market and collateral.
-  - Same fields as `perp_borrowing_group` plus `perp_market_id`, `borrowing_group_id`.
+  - `acc_last_updated_block`, `last_updated_block`, `last_updated_tx_index`,
+    `last_updated_event_index`: bigint
+- **perp_borrowing**: Borrowing rate metrics for a specific market and
+  collateral.
+  - Same fields as `perp_borrowing_group` plus `perp_market_id`,
+    `borrowing_group_id`.
 - **perp_trade**: Current state of open and pending trades.
   - `trader`: text, `id`: bigint (Composite PK)
-  - `trade_type`: perp_trade_type, `perp_market_id`: bigint, `collateral_id`: bigint
+  - `trade_type`: perp_trade_type, `perp_market_id`: bigint, `collateral_id`:
+    bigint
   - `collateral_amount`, `open_collateral_amount`: bigint
-  - `is_long`, `is_open`: boolean, `leverage`, `open_price`, `close_price`: float8
+  - `is_long`, `is_open`: boolean, `leverage`, `open_price`, `close_price`:
+    float8
   - `tp`, `sl`: float8, `referral_code`: text
   - `open_block`, `close_block`: bigint, `last_updated_*`: bigint
-- **perp_trade_history**: Event log of trade changes (opens, closes, liquidations).
+- **perp_trade_history**: Event log of trade changes (opens, closes,
+  liquidations).
   - `id`: bigserial (PK)
-  - `trader`: text, `trade_id`: bigint, `trade_change_type`: perp_trade_change_type
+  - `trader`: text, `trade_id`: bigint, `trade_change_type`:
+    perp_trade_change_type
   - `realized_pnl_pct`: float8, `block`, `tx_index`, `event_index`: bigint
 - **perp_trade_state**: Derived trade metrics (real-time PnL, liq price).
   - `trader`: text, `id`: bigint (Composite PK)
-  - `pnl_pct`, `pnl_collateral`, `borrowing_fee_*`, `closing_fee_*`, `pnl_collateral_after_fees`: float8
+  - `pnl_pct`, `pnl_collateral`, `borrowing_fee_*`, `closing_fee_*`,
+    `pnl_collateral_after_fees`: float8
   - `remaining_collateral_after_fees`, `liquidation_price`: float8
 - **perp_trade_trigger_history**: History of limit/stop order executions.
   - `id`: bigserial (PK)
   - `trader`: text, `trade_id`: bigint, `executor`: text
   - `trigger_type`: perp_trade_trigger_type
   - `trade_trigger_price`, `market_price`: float8
-  - `trigger_execution_block`, `trigger_executed_block`: bigint, `is_success`: boolean, `error_msg`: text
+  - `trigger_execution_block`, `trigger_executed_block`: bigint, `is_success`:
+    boolean, `error_msg`: text
 - **perp_fee**: Fee configuration.
-  - `id`: bigint (PK), `open_fee_p`, `close_fee_p`, `trigger_order_fee_p`: float8, `min_position_size_usd`: bigint
+  - `id`: bigint (PK), `open_fee_p`, `close_fee_p`, `trigger_order_fee_p`:
+    float8, `min_position_size_usd`: bigint
 - **perp_fee_charged_history**: Detailed breakdown of fees paid per trade event.
   - `id`: bigserial (PK)
   - `trader`: text, `trade_id`: bigint, `fee_type`: perp_fee_type
-  - `total_fee_charged`, `vault_fee`, `trigger_fee`, `gov_fee`, `net_gov_fee`, `referrer_allocation`: bigint
-  - `fee_multiplier`: float8, `catalyst_address`: text, `collateral_left`, `bad_debt`: bigint
-  - `open_fee_component`, `trigger_fee_component`, `triggerer_reward`, `final_closing_fee`: bigint
+  - `total_fee_charged`, `vault_fee`, `trigger_fee`, `gov_fee`, `net_gov_fee`,
+    `referrer_allocation`: bigint
+  - `fee_multiplier`: float8, `catalyst_address`: text, `collateral_left`,
+    `bad_debt`: bigint
+  - `open_fee_component`, `trigger_fee_component`, `triggerer_reward`,
+    `final_closing_fee`: bigint
   - `block`, `tx_index`, `event_index`: bigint
 - **perp_open_interest_history**: Time-series of OI per market/group.
-  - `id`: bigint, `id_type`: perp_id_type, `collateral_id`: bigint, `block`, `tx_index`, `event_index` (Composite PK)
+  - `id`: bigint, `id_type`: perp_id_type, `collateral_id`: bigint, `block`,
+    `tx_index`, `event_index` (Composite PK)
   - `oi_long`, `oi_short`: bigint
 - **perp_pending_acc_fees_history**: Time-series of accumulated fees.
-  - `id`: bigint, `id_type`: perp_id_type, `collateral_id`: bigint, `block`, `tx_index`, `event_index` (Composite PK)
+  - `id`: bigint, `id_type`: perp_id_type, `collateral_id`: bigint, `block`,
+    `tx_index`, `event_index` (Composite PK)
   - `acc_fee_long`, `acc_fee_short`: float8
 - **perp_balance_history**: History of contract balances.
   - `block`: bigint, `denom`: text (Composite PK), `balance`: bigint
@@ -127,8 +143,12 @@ This document provides a detailed breakdown of the tables and types in the `sai-
 ### Types
 - **perp_id_type**: `market`, `group`
 - **perp_trade_type**: `trade`, `stop`, `limit`
-- **perp_trade_change_type**: `position_opened`, `limit_order_created`, `stop_order_created`, `order_triggered`, `position_closed_tp`, `position_closed_sl`, `position_liquidated`, `position_closed_user`, `order_closed_user`, `tp_updated`, `sl_updated`, `leverage_updated`
-- **perp_trade_trigger_type**: `limit_open`, `stop_open`, `tp_close`, `sl_close`, `liq_close`
+- **perp_trade_change_type**: `position_opened`, `limit_order_created`,
+  `stop_order_created`, `order_triggered`, `position_closed_tp`,
+  `position_closed_sl`, `position_liquidated`, `position_closed_user`,
+  `order_closed_user`, `tp_updated`, `sl_updated`, `leverage_updated`
+- **perp_trade_trigger_type**: `limit_open`, `stop_open`, `tp_close`,
+  `sl_close`, `liq_close`
 - **perp_fee_type**: `opening`, `closing`
 
 ---
@@ -138,8 +158,11 @@ This document provides a detailed breakdown of the tables and types in the `sai-
 ### Tables
 - **lp_vault**: Current state of SLP vaults.
   - `address`: text (PK)
-  - `shares_denom`, `shares_erc20`, `collateral_denom`, `collateral_erc20`: text
-  - `collateral_id`, `available_assets`, `tvl`, `net_profit`, `rewards`, `closed_pnl`, `liabilities`, `current_epoch_positive_open_pnl`, `current_epoch`, `epoch_start`: bigint
+  - `shares_denom`, `shares_erc20`, `collateral_denom`, `collateral_erc20`:
+    text
+  - `collateral_id`, `available_assets`, `tvl`, `net_profit`, `rewards`,
+    `closed_pnl`, `liabilities`, `current_epoch_positive_open_pnl`,
+    `current_epoch`, `epoch_start`: bigint
   - `share_price`: float8
 - **lp_vault_history**: Historical snapshot of vault metrics.
   - `vault`: text, `block`: bigint (Composite PK)
@@ -148,19 +171,24 @@ This document provides a detailed breakdown of the tables and types in the `sai-
   - `id`: bigserial (PK)
   - `action`: lp_action_type, `depositor`: text, `vault`: text
   - `amount`, `shares`: bigint, `block`, `tx_index`, `event_index`: bigint
-- **lp_vault_assets_received_history**: External asset transfers to vaults (fees, etc).
-  - `vault`: text, `block`: bigint, `tx_index`: bigint, `event_index`: bigint (Composite PK)
+- **lp_vault_assets_received_history**: External asset transfers to vaults
+  (fees, etc).
+  - `vault`: text, `block`: bigint, `tx_index`: bigint, `event_index`: bigint
+    (Composite PK)
   - `sender`: text, `denom`: text, `amount`, `assets_less_deplete`: bigint
 - **lp_vault_pnl_history**: History of PnL changes and distribution to LPs.
-  - `vault`: text, `block`: bigint, `tx_index`: bigint, `event_index`: bigint (Composite PK)
-  - `current_epoch`, `prev_positive_open_pnl`, `new_positive_open_pnl`, `current_epoch_positive_open_pnl`: bigint
+  - `vault`: text, `block`: bigint, `tx_index`: bigint, `event_index`: bigint
+    (Composite PK)
+  - `current_epoch`, `prev_positive_open_pnl`, `new_positive_open_pnl`,
+    `current_epoch_positive_open_pnl`: bigint
   - `acc_pnl_per_token_used`: float8
 - **lp_withdraw_request**: Pending user withdrawal requests.
   - `depositor`: text, `vault`: text, `unlock_epoch`: bigint (Composite PK)
   - `shares`: bigint, `auto_redeem`: boolean
 
 ### Types
-- **lp_action_type**: `deposit`, `create_withdraw_request`, `cancel_withdraw_request`, `redeem`
+- **lp_action_type**: `deposit`, `create_withdraw_request`,
+  `cancel_withdraw_request`, `redeem`
 
 ---
 
@@ -168,13 +196,18 @@ This document provides a detailed breakdown of the tables and types in the `sai-
 
 ### Tables
 - **referral_code**: Registered referral codes.
-  - `code`: text (PK), `referrer`: text, `description`: text, `created_block`: bigint, `is_active`: boolean
+  - `code`: text (PK), `referrer`: text, `description`: text, `created_block`:
+    bigint, `is_active`: boolean
 - **referral_code_creation_history**: Log of code creation.
-  - `id`: bigserial (PK), `code`, `referrer`, `description`: text, `block`, `tx_index`, `event_index`: bigint
+  - `id`: bigserial (PK), `code`, `referrer`, `description`: text, `block`,
+    `tx_index`, `event_index`: bigint
 - **referral_redeem_history**: Log of users redeeming codes.
-  - `id`: bigserial (PK), `trader`, `code`, `referrer`: text, `block`, `tx_index`, `event_index`: bigint
+  - `id`: bigserial (PK), `trader`, `code`, `referrer`: text, `block`,
+    `tx_index`, `event_index`: bigint
 - **referral_claim_history**: History of referral commission claims.
-  - `id`: bigserial (PK), `referrer`: text, `amount`: bigint, `denom`: text, `coin_breakdown`: jsonb, `chain`: text, `block`, `tx_index`, `event_index`: bigint
+  - `id`: bigserial (PK), `referrer`: text, `amount`: bigint, `denom`: text,
+    `coin_breakdown`: jsonb, `chain`: text, `block`, `tx_index`, `event_index`:
+    bigint
 
 ---
 
@@ -185,7 +218,8 @@ Maps time buckets to block ranges.
 ```bash
 psql -d sai_keeper_2 -X -P pager=off -c "\d stats_block_ranges"
 ```
-- `granularity` (stats_granularity): Bucket size (`1m`, `1h`, `1d`, etc); part of composite PK.
+- `granularity` (stats_granularity): Bucket size (`1m`, `1h`, `1d`, etc); part
+  of composite PK.
 - `ts` (timestamptz): Bucket timestamp; part of composite PK.
 - `start_block` (bigint): First chain block included in the bucket.
 - `end_block` (bigint): Last chain block included in the bucket.
@@ -195,7 +229,8 @@ Aggregated oracle prices over time.
 ```bash
 psql -d sai_keeper_2 -X -P pager=off -c "\d stats_oracle_price"
 ```
-- `granularity` (stats_granularity): Aggregation interval; part of composite PK.
+- `granularity` (stats_granularity): Aggregation interval; part of composite
+  PK.
 - `ts` (timestamptz): Bucket timestamp; part of composite PK.
 - `oracle_token_id` (bigint): Oracle token ID; part of composite PK.
 - `avg_price_usd` (float8): Average token price in USD for the bucket.
@@ -219,8 +254,10 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d stats_cache"
 - `total_users_all_time` (bigint): Cumulative distinct users.
 - `total_open_positions` (bigint): Count of currently open positions.
 - `tvl` (numeric): Total value locked in USD.
-- `accrued_trading_fees_24h` (numeric): Rolling 24h accrued trading fees in USD.
-- `accrued_trading_fees_all_time` (numeric): Cumulative accrued trading fees in USD.
+- `accrued_trading_fees_24h` (numeric): Rolling 24h accrued trading fees in
+  USD.
+- `accrued_trading_fees_all_time` (numeric): Cumulative accrued trading fees in
+  USD.
 - `last_updated` (timestamptz): Last cache refresh timestamp.
 
 ### stats_perp_by_user
@@ -252,7 +289,8 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d stats_perp_liq_daily"
 - `trades_count_short` (bigint): Number of liquidated short positions.
 - `volume_long_usd` (numeric): Liquidated long notional volume in USD.
 - `volume_short_usd` (numeric): Liquidated short notional volume in USD.
-- `total_fee_charged_usd` (numeric): Total liquidation-related fees charged in USD.
+- `total_fee_charged_usd` (numeric): Total liquidation-related fees charged in
+  USD.
 - `updated_at` (timestamptz): Timestamp of the last record refresh.
 
 ### stats_perp_oi_daily
@@ -277,8 +315,10 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d stats_slp_deposit_by_user"
 - `vault` (text): SLP vault address; part of composite PK.
 - `amount_deposited_usd` (numeric): USD value deposited during this day.
 - `amount_withdrawn_usd` (numeric): USD value withdrawn during this day.
-- `cumulative_amount_deposited_usd` (numeric): Running cumulative deposited USD for user/vault.
-- `cumulative_amount_withdrawn_usd` (numeric): Running cumulative withdrawn USD for user/vault.
+- `cumulative_amount_deposited_usd` (numeric): Running cumulative deposited USD
+  for user/vault.
+- `cumulative_amount_withdrawn_usd` (numeric): Running cumulative withdrawn USD
+  for user/vault.
 - `updated_at` (timestamptz): Timestamp of the last record refresh.
 
 ### stats_perp_sl_tp_daily
@@ -291,12 +331,17 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d stats_perp_sl_tp_daily"
 - `collateral_id` (bigint): Collateral token ID; part of composite PK.
 - `sl_trades_count_long` (bigint): Number of long trades closed via stop-loss.
 - `sl_trades_count_short` (bigint): Number of short trades closed via stop-loss.
-- `sl_losses_prevented_long_usd` (numeric): Estimated long-side losses prevented by stop-loss in USD.
-- `sl_losses_prevented_short_usd` (numeric): Estimated short-side losses prevented by stop-loss in USD.
+- `sl_losses_prevented_long_usd` (numeric): Estimated long-side losses prevented
+  by stop-loss in USD.
+- `sl_losses_prevented_short_usd` (numeric): Estimated short-side losses
+  prevented by stop-loss in USD.
 - `tp_trades_count_long` (bigint): Number of long trades closed via take-profit.
-- `tp_trades_count_short` (bigint): Number of short trades closed via take-profit.
-- `tp_profit_realized_long_usd` (numeric): Realized long-side take-profit in USD.
-- `tp_profit_realized_short_usd` (numeric): Realized short-side take-profit in USD.
+- `tp_trades_count_short` (bigint): Number of short trades closed via
+  take-profit.
+- `tp_profit_realized_long_usd` (numeric): Realized long-side take-profit in
+  USD.
+- `tp_profit_realized_short_usd` (numeric): Realized short-side take-profit in
+  USD.
 - `updated_at` (timestamptz): Timestamp of the last record refresh.
 
 ### stats_perp_fee_daily
@@ -310,23 +355,31 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d stats_perp_fee_daily"
 - `opening_fee_count` (integer): Count of opening-fee events.
 - `opening_fee_total` (bigint): Total opening fees in base collateral units.
 - `opening_fee_total_usd` (float8): Total opening fees in USD.
-- `opening_vault_fee` (bigint): Opening-fee portion allocated to vaults (base units).
-- `opening_vault_fee_usd` (float8): Opening-fee portion allocated to vaults (USD).
+- `opening_vault_fee` (bigint): Opening-fee portion allocated to vaults (base
+  units).
+- `opening_vault_fee_usd` (float8): Opening-fee portion allocated to vaults
+  (USD).
 - `opening_trigger_fee` (bigint): Opening trigger-order fees (base units).
 - `opening_trigger_fee_usd` (float8): Opening trigger-order fees (USD).
-- `opening_gov_fee` (bigint): Opening-fee protocol/governance allocation (base units).
-- `opening_gov_fee_usd` (float8): Opening-fee protocol/governance allocation (USD).
+- `opening_gov_fee` (bigint): Opening-fee protocol/governance allocation (base
+  units).
+- `opening_gov_fee_usd` (float8): Opening-fee protocol/governance allocation
+  (USD).
 - `opening_referrer_fee` (bigint): Opening-fee referrer allocation (base units).
 - `opening_referrer_fee_usd` (float8): Opening-fee referrer allocation (USD).
 - `closing_fee_count` (integer): Count of closing-fee events.
 - `closing_fee_total` (bigint): Total closing fees in base collateral units.
 - `closing_fee_total_usd` (float8): Total closing fees in USD.
-- `closing_vault_fee` (bigint): Closing-fee portion allocated to vaults (base units).
-- `closing_vault_fee_usd` (float8): Closing-fee portion allocated to vaults (USD).
+- `closing_vault_fee` (bigint): Closing-fee portion allocated to vaults (base
+  units).
+- `closing_vault_fee_usd` (float8): Closing-fee portion allocated to vaults
+  (USD).
 - `closing_trigger_fee` (bigint): Closing trigger-order fees (base units).
 - `closing_trigger_fee_usd` (float8): Closing trigger-order fees (USD).
-- `closing_gov_fee` (bigint): Closing-fee protocol/governance allocation (base units).
-- `closing_gov_fee_usd` (float8): Closing-fee protocol/governance allocation (USD).
+- `closing_gov_fee` (bigint): Closing-fee protocol/governance allocation (base
+  units).
+- `closing_gov_fee_usd` (float8): Closing-fee protocol/governance allocation
+  (USD).
 - `closing_referrer_fee` (bigint): Closing-fee referrer allocation (base units).
 - `closing_referrer_fee_usd` (float8): Closing-fee referrer allocation (USD).
 - `total_bad_debt` (bigint): Aggregate bad debt amount in base collateral units.
@@ -354,9 +407,11 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d stats_slp_vault"
 - `vault` (text): SLP vault address; part of composite PK.
 - `share_price` (float8): Vault share price at snapshot time.
 - `apy` (float8): Annual percentage yield estimate.
-- `deposits` (float8): Deposited collateral amount in token units for the bucket.
+- `deposits` (float8): Deposited collateral amount in token units for the
+  bucket.
 - `deposits_usd` (float8): Deposited amount converted to USD.
-- `withdrawals` (float8): Withdrawn collateral amount in token units for the bucket.
+- `withdrawals` (float8): Withdrawn collateral amount in token units for the
+  bucket.
 - `withdrawals_usd` (float8): Withdrawn amount converted to USD.
 - `volume` (float8): Total vault activity volume in token units.
 - `volume_usd` (float8): Total vault activity volume in USD.
@@ -388,12 +443,15 @@ Time-series of user PnL and volume.
 ```bash
 psql -d sai_keeper_2 -X -P pager=off -c "\d stats_user_portfolio"
 ```
-- `granularity` (stats_granularity): Aggregation interval; part of composite PK.
+- `granularity` (stats_granularity): Aggregation interval; part of composite
+  PK.
 - `ts` (timestamptz): Bucket timestamp; part of composite PK.
 - `user_address` (text): User wallet address; part of composite PK.
 - `realized_pnl_usd` (float8): Realized PnL in USD in this bucket.
-- `realized_pnl_usd_cumulative` (float8): Running cumulative realized PnL in USD.
-- `pending_pnl_usd_cumulative` (float8): Running cumulative unrealized (pending) PnL in USD.
+- `realized_pnl_usd_cumulative` (float8): Running cumulative realized PnL in
+  USD.
+- `pending_pnl_usd_cumulative` (float8): Running cumulative unrealized (pending)
+  PnL in USD.
 - `volume_usd` (float8): Trading volume in USD in this bucket.
 - `volume_usd_cumulative` (float8): Running cumulative trading volume in USD.
 - `trades_count` (bigint): Number of trades in this bucket.
@@ -418,7 +476,8 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d volume_leaderboard"
 - `trader` (text): Trader address (PK).
 - `volume_usd` (numeric): Cumulative trading volume in USD for ranking.
 - `last_tracked_block` (bigint): Last block included in refresh.
-- `threshold_block` (bigint): Optional lower-bound block used for scoped volume windows.
+- `threshold_block` (bigint): Optional lower-bound block used for scoped volume
+  windows.
 
 ### statsig_last_tracked_block
 Tracks progress of stats refreshers.
@@ -429,4 +488,5 @@ psql -d sai_keeper_2 -X -P pager=off -c "\d statsig_last_tracked_block"
 - `last_tracked_block` (bigint): Latest processed block for that event type.
 
 ### Types
-- **stats_granularity**: `1s`, `1m`, `5m`, `15m`, `1h`, `4h`, `6h`, `12h`, `1d`, `1w`, `1mo`
+- **stats_granularity**: `1s`, `1m`, `5m`, `15m`, `1h`, `4h`, `6h`, `12h`,
+  `1d`, `1w`, `1mo`


### PR DESCRIPTION
- **docs(README): Describe ai-skills directory**
- **ai-skills(commit-diff): Take a more opinionated approach to the messages**
- **ai-skills(epics-plus): Fix bug in example command**
- **ai-skills: Upload justfile skill**
- **ai-skills(sai-db): Correction in schema.md**
- **ai-skills(nibiru-cli-nibid): Add note on how to query Wasm via introspection without access to the contract source code**
- **ai-skills: Impl drill-spec**
- **ai-skills: Impl lang-caveman**
- **ai-skills: Impl bash-defensive-patterns**
- **ai-skills: find-skills**
- **ai-skills: new-chat-prompt**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds and tweaks markdown documentation under `ai-skills/` plus a README update; no production code paths or runtime behavior changes.
> 
> **Overview**
> Adds an `ai-skills/` section to the root `README.md` and documents it as a shared library of Cursor/LLM operational playbooks.
> 
> Introduces several new skills (e.g., `bash-defensive-patterns`, `just`, `find-skills`, `drill-spec`, `lang-caveman`, `new-chat-prompt`) and expands existing ones by tightening `commit-diff` commit-message conventions, fixing the `epics-plus` example flag, and adding a `nibid` Wasm query introspection tip.
> 
> Includes minor doc formatting/clarity fixes in `sai-db/schema.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f913634c274566827ff4825ee470e2403ee131c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->