### PR TITLE
epic: Sync skills to remote 

### DIFF
--- a/ai-skills/drill-spec/SKILL.md
+++ b/ai-skills/drill-spec/SKILL.md
@@ -5,6 +5,12 @@ description: Interview the user relentlessly about a plan, spec, or design until
 
 Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 
-Ask the questions one at a time.
+1. Ask the questions one at a time.
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+2. If a question can be answered by exploring the codebase, explore the codebase instead.
+
+3. Record decisions as the discussion progresses. If the user is working from an
+existing spec, plan, issue, or design document, write the resolved answers back
+into that document iteratively. If there is no obvious document, create or
+propose a short notes/spec file and use it to capture decisions, open questions,
+and rationale so the drill does not remain only in chat.

--- a/ai-skills/epics-plus/SKILL.md
+++ b/ai-skills/epics-plus/SKILL.md
@@ -7,16 +7,16 @@ description: Discover, read, and manage Epics+ markdown documents in the boku re
 
 Navigate, interpret, and manage Epics+ docs in the boku repository. Use this skill to understand the status and priority of work, and to use the `epics-plus` tooling.
 
-## Quick Start
+## Quick Start and Usage Modes
 
 1. **Check active work**: Read [epics/INDEX.md](/home/realu/ki/boku/epics/INDEX.md) for the current dashboard of active epics grouped by priority.
-2. **Regenerate index**: If you've modified frontmatter or added an epic, update the dashboard:
-   ```bash
-   cd /home/realu/ki/boku/epics && just epics-plus index
-   ```
-3. **Verify/Scan**: To see all epics with frontmatter or validate them:
+2. **Verify/Scan**: To see all epics with frontmatter or validate them:
    ```bash
    cd /home/realu/ki/boku/epics && just epics-plus scan --fm-only --strict
+   ```
+3. **Regenerate index**: If you've modified frontmatter or added an epic, update the dashboard:
+   ```bash
+   cd /home/realu/ki/boku/epics && just epics-plus index
    ```
 
 ## Interpreting Epics+ Frontmatter (Reader View)
@@ -28,8 +28,123 @@ When reading an epic doc, look at the YAML frontmatter at line 1 for context:
 - **epic_kind**: `spec` | `journal` | `reference`.
 - **tags**: Broad themes (e.g., `sai`, `evm`, `slashing`). Use for "related work" queries.
 - **repos**: Which codebase this epic targets (e.g., `nibi-chain`, `sai-keeper`).
+  These use the conventional repo names from the `/repo-map` skill.
 - **related_context**: Links to other epics (`/epics/...`). Follow these to understand dependencies.
 - **agent_skills**: Cursor skill IDs relevant to this epic. Suggest using them when working on the task.
+
+## Commands Reference
+
+Run from `/home/realu/ki/boku/epics`:
+
+- `just epics-plus index`: Writes `INDEX.md`.
+  - `--dry-run`: Print to stdout instead.
+  - `--all-statuses`: Include inactive/done/archived epics.
+- `just epics-plus scan`: List epics.
+  - `--fm-only`: Skip files without Epics+ YAML.
+  - `--strict`: Exit non-zero if validation fails.
+  - `--format ndjson`: Useful for batch processing.
+
+- Index generation dashboard: [epics/INDEX.md](/home/realu/ki/boku/epics/INDEX.md)
+
+## Additional Resources
+- Full schema and semantics: [epics/26-02-24-epics-plus.md](/home/realu/ki/boku/epics/26-02-24-epics-plus.md)
+
+## Mode: Finding or Searching for Epics
+
+Use this procedure when the user asks to find, search, locate, resolve, or get
+the path for an epic.
+
+Example invocations:
+```
+/epics-plus Find me the recent epic on publishing my Go release on npm
+/epics-plus Search for the epic on creating new markets on Sai
+```
+
+### Procedure
+
+First, query the lightweight Epics+ metadata:
+
+```bash
+cd /home/realu/ki/boku
+just epics-plus scan --fm-only --json path,title,data
+```
+
+Use the returned JSON to search across:
+- `path`
+- `title`
+- `data.title`
+- `data.status`
+- `data.priority`
+- `data.epic_kind`
+- `data.created`
+- `data.tags`
+- `data.repos`
+- `data.related_context`
+- `data.agent_skills`
+
+Prefer active epics by default, unless the user explicitly asks for archived,
+done, inactive, or all epics.
+
+If the metadata scan is not enough, also search within:
+
+```bash
+/home/realu/ki/boku/epics
+```
+
+Search file paths, headings, and body text as needed.
+
+### Ranking
+
+Prefer matches in this order:
+- Strong title or filename/path match.
+- Query terms appearing in `data.tags`, `data.repos`, or `data.agent_skills`.
+- Query terms appearing in `data.related_context`.
+- Recent `data.created` date when the user asks for recent work.
+- Higher priority when otherwise tied: `p0`, `p1`, `p2`, `p3`.
+
+### Output
+
+If one clear epic matches, report the absolute path in a code block:
+
+```txt
+/home/realu/ki/boku/epics/26-05-05-go-cli-npm.md
+```
+
+If multiple epics may match, report all plausible absolute paths in a code block,
+then add a short note with titles so the user can choose:
+
+```txt
+/home/realu/ki/boku/epics/26-03-25-sai-new-markets/README.md
+/home/realu/ki/boku/epics/26-03-25-sai-new-markets/mktg-go-live.md
+```
+
+When no match is found, say that no matching epic was found and mention whether
+you searched metadata only or also searched the epics directory body text.
+
+### Applying Search Filters by Status 
+
+By default, `scan` returns active epics only. When the user asks for other
+statuses or a different result window, use long-form flags:
+
+```bash
+# Find up to 20 active epics (default status and limit)
+just epics-plus scan --fm-only --json path,title,data
+
+# Find up to 50 active epics
+just epics-plus scan --fm-only --limit 50 --json path,title,data
+
+# Find done epics
+just epics-plus scan --fm-only --status done --limit 20 --json path,title,data
+
+# Find inactive epics
+just epics-plus scan --fm-only --status inactive --limit 20 --json path,title,data
+
+# Find inactive or done epics
+just epics-plus scan --fm-only --status inactive,done --limit 50 --json path,title,data
+
+# Remove status filtering and search all frontmatter epics
+just epics-plus scan --fm-only --status all --limit 100 --json path,title,data
+```
 
 ## Recommended Workflow
 
@@ -45,18 +160,3 @@ When assigned to an epic, open the file and:
 ### 3. Maintenance
 Regenerate the index after any frontmatter changes so the dashboard stays accurate.
 
-## Commands Reference
-
-Run from `/home/realu/ki/boku/epics`:
-
-- `just epics-plus index`: Writes `INDEX.md`.
-  - `--dry-run`: Print to stdout instead.
-  - `--all-statuses`: Include inactive/done/archived epics.
-- `just epics-plus scan`: List epics.
-  - `--fm-only`: Skip files without Epics+ YAML.
-  - `--strict`: Exit non-zero if validation fails.
-  - `--format ndjson`: Useful for batch processing.
-
-## Additional Resources
-- Full schema and semantics: [epics/26-02-24-epics-plus.md](/home/realu/ki/boku/epics/26-02-24-epics-plus.md)
-- Index generation dashboard: [epics/INDEX.md](/home/realu/ki/boku/epics/INDEX.md)

--- a/ai-skills/gh-pr-review/SKILL.md
+++ b/ai-skills/gh-pr-review/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: gh-pr-review
+description: Review GitHub pull requests for correctness, design quality, test coverage, security, performance, and backward compatibility. Use when reviewing PRs, when asked to review code changes, or when the user mentions "review PR", "code review", or "check this PR".
+---
+
+# GitHub PR Review Skill
+
+Review pull requests with emphasis on what automated checks usually miss:
+correctness, design quality, security, backward compatibility, test adequacy,
+maintainability, concurrency risks, and performance regressions.
+
+## Usage Modes
+
+### No Argument
+
+If the user invokes `/gh-pr-review` with no arguments, do not perform a review.
+Ask what they want reviewed:
+
+> What would you like me to review?
+> - A PR number or URL, for example `/gh-pr-review 12345`
+> - A local branch, for example `/gh-pr-review branch`
+
+### Pull Request Mode
+
+The user provides a PR number or URL:
+
+```
+/gh-pr-review 12345
+/gh-pr-review https://github.com/org/repo/pull/12345
+```
+
+For a detailed review with line-specific comments:
+
+```
+/gh-pr-review 12345 detailed
+```
+
+Use `gh` CLI to fetch PR data:
+
+```bash
+# Get PR details
+gh pr view <PR_NUMBER> --json title,body,author,baseRefName,headRefName,files,additions,deletions,commits
+
+# Get the diff
+gh pr diff <PR_NUMBER>
+
+# Get PR comments and reviews
+gh pr view <PR_NUMBER> --json comments,reviews
+```
+
+### Local Branch Mode
+
+Review changes in the current branch that are not in `main`:
+
+```
+/gh-pr-review branch
+/gh-pr-review branch detailed
+```
+
+Use git commands to understand branch changes:
+
+```bash
+# Get current branch name
+git branch --show-current
+
+# Get list of changed files compared to main
+git diff --name-only main...HEAD
+
+# Get full diff compared to main
+git diff main...HEAD
+
+# Get commit log for the branch
+git log main..HEAD --oneline
+
+# Get diff stats
+git diff --stat main...HEAD
+```
+
+For local branch reviews:
+- The Summary should describe what the branch changes accomplish based on commit messages and diff.
+- Use the current branch name in the review header instead of a PR number.
+- All other review criteria apply the same as PR reviews.
+
+### GitHub Actions Mode
+
+When invoked from a GitHub PR automation, PR metadata may already be injected
+into the prompt. Detect this mode by the presence of structured PR context,
+PR body, comments, or review comments in the prompt.
+
+The prompt may already contain:
+- PR metadata: title, author, branch names, additions/deletions, and file count
+- PR body or description
+- Comments and review comments with file or line references
+- Changed file paths and change types
+
+Use git commands to get the diff and commit history. The base branch name is in
+the prompt context, for example `PR Branch: <head> -> <base>` or a `baseBranch`
+field.
+
+```bash
+# Get the full diff against the base branch
+git diff origin/<baseBranch>...HEAD
+
+# Get diff stats
+git diff --stat origin/<baseBranch>...HEAD
+
+# Get commit history for this PR
+git log origin/<baseBranch>..HEAD --oneline
+
+# If the base branch ref is not available, fetch it first
+git fetch origin <baseBranch> --depth=1
+```
+
+Do not use `gh` CLI commands in this mode if the action environment only
+provides git and injected PR metadata.
+
+## Review Philosophy
+
+2. **Investigate, don't guess** - When uncertain whether a checklist item
+   applies, inspect surrounding code or spawn a sub-agent to gather context.
+3. **Review the design, not just the implementation** - Question hidden state,
+   side-channel behavior, unclear ownership, fragile ordering, and missing
+   interface contracts.
+5. **Everything reported should matter** - Avoid nits. If it is worth writing
+   down, it should affect correctness, maintainability, security, performance,
+   compatibility, or reviewability.
+6. **Be specific and actionable** - Reference file paths and line numbers.
+   Name the function, module, pattern, or API the author should use.
+7. **Match the immediate context** - Read how similar behavior is already
+   implemented nearby before flagging or accepting a pattern.
+8. **Assume competence** - Explain only the context needed to make the requested
+   change clear.
+9. **No repetition** - Each observation appears in exactly one section.
+
+### Using Sub-Agents
+
+For medium or large PRs, spawn sub-agents to investigate independent areas:
+changed subsystems, expected test locations, public API callers, security
+surfaces, or unfamiliar infrastructure. Ask each sub-agent to return concise
+evidence and file references, not a full review.
+
+Before finalizing, fact-check each reported issue. For every non-obvious claim,
+re-read the relevant code or ask a sub-agent to verify it as **valid**,
+**invalid**, or **needs rewording**. Drop invalid issues and reword unclear ones.
+
+## Review Workflow
+
+### Step 1: Understand Context
+
+Before reviewing, build a clear picture of what changed and why:
+
+1. Identify the purpose of the change from title, description, linked issue, and
+   commit messages.
+2. Group changes by type: product behavior, API, data model, tests, docs,
+   configuration, build, or deployment.
+3. Note the size and risk profile: changed files, touched subsystems, public
+   interfaces, persisted data, and production paths.
+4. Read surrounding code for significantly changed files to understand existing
+   patterns.
+5. Review prior comments so you do not duplicate feedback or miss existing
+   reviewer concerns.
+
+### Step 2: Deep Review
+
+Evaluate each meaningful changed line against the checklist below. Prioritize
+bugs and risks over style preferences.
+
+### Step 3: Check Backward Compatibility
+
+Backward compatibility matters for public APIs, persisted data, configuration,
+wire protocols, CLI behavior, migrations, user-visible behavior, and stable
+integrations.
+
+Check for:
+- Removed, renamed, or re-scoped public interfaces.
+- Changed function signatures, required parameters, defaults, return shapes, or
+  error behavior.
+- Changed persisted formats, migration assumptions, or deployment order
+  requirements.
+- Silent behavior changes that existing users may not notice until production.
+- Missing migration path, release note, or compatibility window for intentional
+  breaks.
+
+When unsure, ask:
+1. Would existing usage break silently?
+2. Would existing usage fail loudly but recoverably?
+3. Is there a migration path that avoids immediate user action?
+4. Is the behavior documented and covered by tests?
+5. Does the PR clearly explain why the compatibility risk is acceptable?
+
+### Step 4: Formulate Review
+
+Write findings as concrete requests. Each finding should include the affected
+file or behavior, why it matters, and what change would resolve it.
+
+### Step 5: Final Recommendation
+
+Recommend one of:
+- **Approve** - No blocking issues.
+- **Request Changes** - Correctness, security, compatibility, data-loss,
+  production, or missing-test risks block merge.
+- **Needs Discussion** - The core issue is design, product intent, migration
+  strategy, or ownership and needs agreement before implementation changes.
+
+Missing tests for new behavior or bug fixes normally means **Request Changes**.
+
+## Review Checklist
+
+### Correctness
+
+- [ ] The implementation matches the stated product or technical intent.
+- [ ] Edge cases, empty inputs, invalid inputs, and failure paths are handled.
+- [ ] State transitions are explicit and reversible where needed.
+- [ ] Ordering assumptions are documented or enforced by code.
+- [ ] Errors are surfaced at the right level with enough context to debug.
+- [ ] The change does not introduce stale reads, lost writes, double execution,
+      duplicate registration, or cleanup gaps.
+
+### Design And Maintainability
+
+- [ ] Abstractions are clear and necessary for the current requirements.
+- [ ] New interfaces have clear ownership, invariants, and lifecycle behavior.
+- [ ] Hidden flags, side-channel state, and implicit calling conventions are
+      avoided or clearly justified.
+- [ ] The code follows established local patterns in the same module or nearby
+      subsystem.
+- [ ] Helpers are not created for one-off trivial logic unless they improve
+      readability meaningfully.
+- [ ] Documentation and examples show the correct path directly, not a confusing
+      mix of anti-patterns and corrections.
+
+### API And Compatibility
+
+- [ ] Public or stable interfaces remain compatible, or the PR includes a clear
+      migration plan.
+- [ ] Defaults, required parameters, return values, error types, and side effects
+      are unchanged unless intentionally documented.
+- [ ] Persisted data, schema changes, and protocol changes are backward and
+      forward compatible where deployment ordering requires it.
+- [ ] Deprecated paths remain available long enough for users to migrate.
+- [ ] Compatibility risks are called out in release notes, docs, or PR text.
+
+### Testing
+
+- [ ] New behavior has focused tests.
+- [ ] Bug fixes include regression tests that fail without the fix.
+- [ ] Tests are placed near related coverage instead of creating isolated test
+      files unnecessarily.
+- [ ] Tests cover boundary conditions, negative cases, and representative real
+      usage.
+- [ ] Assertions verify important outputs and error messages, not just that code
+      executes.
+- [ ] Tests avoid brittle timing, ordering, environment, and network assumptions.
+- [ ] Shared fixtures or helpers reduce duplication without hiding the key test
+      behavior.
+
+### Security
+
+- [ ] Inputs crossing trust boundaries are validated, normalized, and bounded.
+- [ ] The change does not expose secrets, credentials, tokens, internal URLs, or
+      sensitive logs.
+- [ ] Authentication, authorization, and tenancy checks remain enforced on every
+      path.
+- [ ] File paths, shell commands, URLs, redirects, templates, and queries are not
+      vulnerable to injection or traversal.
+- [ ] Deserialization, dynamic evaluation, plugin loading, and dependency changes
+      do not expand the attack surface unnecessarily.
+- [ ] CI, deployment, and release changes do not grant untrusted code access to
+      sensitive credentials or privileged environments.
+
+### Concurrency And Reliability
+
+- [ ] Shared mutable state is synchronized or confined to one owner.
+- [ ] Multiple locks or resources are acquired in a consistent order.
+- [ ] Retries are idempotent or have safeguards against duplicate side effects.
+- [ ] Timeouts, cancellation, cleanup, and partial failure behavior are defined.
+- [ ] Background jobs, queues, listeners, and subscriptions cannot leak or run
+      after their owner is gone.
+- [ ] Distributed or multi-process behavior handles race conditions and stale
+      state.
+
+### Performance
+
+- [ ] Hot paths avoid unnecessary allocations, repeated parsing, excessive I/O,
+      and avoidable network calls.
+- [ ] Loops and queries scale with expected data size.
+- [ ] Caches have clear invalidation, bounds, and ownership.
+- [ ] Large payloads are streamed, paginated, batched, or bounded where needed.
+- [ ] The PR includes benchmarks or measurements for risky performance-sensitive
+      changes.
+
+### Observability And Operations
+
+- [ ] Important failures have logs, metrics, traces, or events at the right
+      level.
+- [ ] Logs include useful context without leaking sensitive data.
+- [ ] Feature flags, migrations, rollouts, and rollback paths are clear for
+      production changes.
+- [ ] Configuration changes have safe defaults and validation.
+- [ ] Alerts or dashboards are updated when production behavior changes.
+
+## Output Format
+
+Structure reviews like this. Omit sections where there are no problems to
+report. Do not write "No concerns" or affirmative filler.
+
+```markdown
+## PR Review: #<number>
+<!-- Or for local branch reviews: -->
+## Branch Review: <branch-name> (vs main)
+
+### Summary
+What the PR does in one sentence, followed by the overall verdict.
+
+### Correctness
+[Problems only]
+
+### Design And Maintainability
+[Problems only]
+
+### API And Compatibility
+[Problems only]
+
+### Testing
+[Problems only]
+
+### Security
+[Problems only]
+
+### Concurrency And Reliability
+[Problems only]
+
+### Performance
+[Problems only]
+
+### Observability And Operations
+[Problems only]
+
+### Recommendation
+**Approve** / **Request Changes** / **Needs Discussion**
+
+[Brief justification focused on what blocks approval, if anything]
+```
+
+### Specific Comments
+
+Only include this section if the user requests a detailed or in-depth review.
+Do not repeat observations already made in other sections. Use it for additional
+file-specific feedback that does not fit the categorized sections.
+
+```markdown
+### Specific Comments
+- `src/module.ts:42` - This branch does not handle an empty result set, so the caller receives a success response with incomplete data.
+- `test/module.test.ts:100-105` - Add a regression test for the error path introduced by this change.
+```
+
+## Files To Reference
+
+When reviewing, consult project files for context rather than relying on memory.
+Common examples include:
+
+- Repository instructions such as `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`,
+  `AGENTS.md`, or `.cursor/rules/`.
+- Existing tests near the changed code.
+- Nearby implementations of the same pattern.
+- API docs, migration docs, release notes, or schema definitions touched by the
+  PR.
+- Build, CI, deployment, and configuration files changed by the PR.

--- a/ai-skills/md-tasks/SKILL.md
+++ b/ai-skills/md-tasks/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: md-tasks
+description: >-
+  Apply consistent Markdown checkbox task conventions in READMEs, epics/journals,
+  specs, and design docs. Use when the user wants task lists with "- [ ]" /
+  "- [x]", nested subtasks, context sub-bullets under items, or terminal
+  commands (grep/rg) to list open versus completed tasks in Markdown files —
+  especially in repo documentation and planning Markdown.
+---
+
+# Markdown tasks and checkbox conventions
+
+Follow these conventions so agents and humans can scan open work reliably.
+
+## Usage guidelines
+
+### Checkbox notation
+
+Denote open tasks or TODOs with standard checkbox notation:
+
+- `- [ ]` for incomplete tasks.
+- `- [x]` for done tasks.
+
+Indentation defines subtasks: extra leading spaces nest bullets under a parent item.
+
+Often add ordinary sub-bullets for status or context beneath a task, for example:
+
+```markdown
+- [ ] Some task
+  - Status: maybe some status description or how it was completed
+  - More context
+  - [ ] Subtask A
+```
+
+This keeps review tight: unfinished work sorts visually to checklist lines while
+still allowing narrative detail.
+
+### Finding tasks in the terminal
+
+Patterns differ by shell (`**/*.md` is not universal glob). Typical approaches:
+
+```bash
+# Completed tasks under a directory (GNU grep fallback)
+grep -rF -- '- [x]' <path-or-glob>
+
+# Open tasks — limit to Markdown (example: cwd tree)
+grep -rF -- '- [ ]' . --include='*.md'
+```
+
+Or use **`rg`** for `**` globs and filters:
+
+```bash
+rg --fixed-strings -g '*.md' -- '- [ ]'
+rg --fixed-strings -g '*.md' -- '- [x]'
+```
+
+Tune paths and `-g`/globbing to match the repo layout.

--- a/ai-skills/nibiru-cli-nibid/SKILL.md
+++ b/ai-skills/nibiru-cli-nibid/SKILL.md
@@ -13,6 +13,38 @@ authoritative chain view or wants to submit a transaction with `nibid`.
 - EVM account, FunToken, and unit notes: [`reference.md`](./reference.md)
 - Copy-paste examples: [`examples.md`](./examples.md)
 
+## Installing `nibid`
+
+Nibiru publishes a bash installer at `https://get.nibiru.fi/`. The URL behaves
+like a small package installer:
+
+```bash
+# Recommended: install the default/latest generated release onto PATH.
+curl -s https://get.nibiru.fi/! | bash
+
+# Install a specific release into the current directory as ./nibid.
+curl -s https://get.nibiru.fi/@v2.12.0-p1 | bash
+
+# Install a specific release onto PATH at /usr/local/bin/nibid.
+# The trailing ! makes the generated script set OUT_DIR="/usr/local/bin" and
+# may ask for sudo.
+curl -s https://get.nibiru.fi/@v2.12.0-p1! | bash
+```
+
+Rules of thumb:
+
+- The `@version` segment selects the release tag used in the generated GitHub
+  asset URLs.
+- Prefer the trailing `!` form for the default install command so `nibid` lands
+  at `/usr/local/bin/nibid`.
+- Without `!`, the generated script uses `OUT_DIR="$(pwd)"` and writes
+  `./nibid`.
+- With trailing `!`, the generated script uses `OUT_DIR="/usr/local/bin"` so
+  `nibid` is available on PATH.
+- `https://get.nibiru.fi/?type=script` is useful for reading the generated
+  script logic, not for specifying versions.
+- After installing, verify with `which nibid` and `nibid version`.
+
 ## Quick start
 
 1. Select the chain config with your `ud` wrapper:

--- a/ai-skills/nibiru-cli-nibid/examples.md
+++ b/ai-skills/nibiru-cli-nibid/examples.md
@@ -36,7 +36,6 @@ nibid tx bank send \
   "$AMOUNT" \
   --note "$MEMO" \
   --chain-id "cataclysm-1" \
-  --node "https://rpc.archive.nibiru.fi:443" \
   --fees "5000unibi" \
   --gas auto \
   --gas-adjustment 1.3 \

--- a/ai-skills/repo-map/SKILL.md
+++ b/ai-skills/repo-map/SKILL.md
@@ -61,3 +61,25 @@ frontend and API integrations. This uses the "sai-keeper" GraphQL interface.
   content in `src/content/post/` (schema in `src/content/config.ts`). Site config
   `src/config.yaml`, nav `src/navigation.js`. Run `just dev`, build `just b`,
   deploy `just deploy`.
+
+## GitHub Remotes and Git Cloning
+
+### Repos with Prefix "sai-" or "nibi-" (`$HOME/ki`)
+
+Nibiru work lives under org **`NibiruChain`**. Local directory names often **differ** from the repository slug (e.g. clone `nibiru` into **`nibi-chain`**, `web-app` into **`sai-website`**). **`gh repo list NibiruChain`** lists canonical slugs for your account.
+
+| Local folder | Remote |
+|--------------|--------|
+| `nibi-chain` | `git@github.com:NibiruChain/nibiru.git` |
+| `nibi-geth` | `git@github.com:NibiruChain/go-ethereum.git` |
+| `nibi-go-hm` | `git@github.com:NibiruChain/heart-monitor.git` |
+| `nibi-ts-sdk` | `git@github.com:NibiruChain/ts-sdk.git` |
+| `sai-website` | `git@github.com:NibiruChain/web-app.git` |
+| `sai-perps` | `git@github.com:NibiruChain/sai-perps.git` |
+| `sai-keeper` | `git@github.com:NibiruChain/sai-keeper.git` |
+| `sai-docs` | `git@github.com:NibiruChain/sai-docs.git` |
+| `nibi-iac` | `git@github.com:NibiruChain/iac.git` |
+
+Other entries in this map: **`wasm-cosmwasm`** → `git@github.com:CosmWasm/cosmwasm.git`; **`wasm-go-wasmvm`** → `git@github.com:CosmWasm/wasmvm.git`; **`boku`** → `git@github.com:Unique-Divine/boku.git` (personal).
+
+Copy-paste **`git clone`** commands, optional idempotent **`clone`** helper function, and notes on discovering org repos: [cloning.md](./cloning.md).

--- a/ai-skills/repo-map/cloning.md
+++ b/ai-skills/repo-map/cloning.md
@@ -1,0 +1,98 @@
+# Cloning — `$HOME/ki` layout (NibiruChain and related)
+
+Use this when recreating the machine layout under **`$HOME/ki`**. All **NibiruChain** URLs use SSH; ensure `git@github.com` works for your keys.
+
+## Discover NibiruChain slugs
+
+```bash
+gh repo list NibiruChain --limit 500 --json name --jq '.[].name' | sort
+```
+
+If the list truncates, raise `--limit` or run `gh api orgs/NibiruChain/repos --paginate`.
+
+## NibiruChain — `git clone` (slug → local folder)
+
+From an empty or partial `~/ki`, run only the lines you still need (skip if the directory already exists).
+
+```bash
+mkdir -p "$HOME/ki"
+cd "$HOME/ki"
+
+git clone git@github.com:NibiruChain/nibiru.git nibi-chain
+git clone git@github.com:NibiruChain/go-ethereum.git nibi-geth
+git clone git@github.com:NibiruChain/heart-monitor.git nibi-go-hm
+git clone git@github.com:NibiruChain/ts-sdk.git nibi-ts-sdk
+git clone git@github.com:NibiruChain/web-app.git sai-website
+git clone git@github.com:NibiruChain/sai-perps.git sai-perps
+git clone git@github.com:NibiruChain/sai-keeper.git sai-keeper
+git clone git@github.com:NibiruChain/sai-docs.git sai-docs
+git clone git@github.com:NibiruChain/iac.git nibi-iac
+```
+
+The **`nibiru`** checkout also contains **`nibi-chain/sai-trading/`** (trading bot automation); there is **no** separate clone for that path.
+
+Sanity-check: `git -C ~/ki/<folder> remote get-url origin` should show `NibiruChain/<slug>.git`; the **`folder`** name is chosen for ergonomics and may not equal **`slug`** (see table in [SKILL.md](./SKILL.md)).
+
+## Wasm / toolchain (upstream CosmWasm, not NibiruChain)
+
+```bash
+mkdir -p "$HOME/ki"
+cd "$HOME/ki"
+
+git clone git@github.com:CosmWasm/cosmwasm.git wasm-cosmwasm
+git clone git@github.com:CosmWasm/wasmvm.git wasm-go-wasmvm
+```
+
+## Personal repos (examples)
+
+These are **outside** `NibiruChain`; URLs follow your forks.
+
+```bash
+cd "$HOME/ki"
+
+git clone git@github.com:Unique-Divine/boku.git boku
+
+# gh-io-ud: replace with your fork if different
+git clone git@github.com:Unique-Divine/gh-io-ud.git gh-io-ud
+```
+
+## Optional: idempotent **`clone`** function
+
+Runs the same clones as above; skips directories that already contain **`.git`**. Paste into **`~/.zshrc`** or run in a subshell:
+
+```bash
+clone_nibiruchain_ki() {
+  mkdir -p "$HOME/ki" || return 1
+  (
+    cd "$HOME/ki" || return 1
+    clone_into() {
+      local slug="$1" dir="$2"
+      if [[ -d "$dir/.git" ]]; then
+        echo "skip existing: $dir"
+        return 0
+      fi
+      git clone "git@github.com:NibiruChain/${slug}.git" "$dir"
+    }
+    clone_into nibiru               nibi-chain
+    clone_into go-ethereum           nibi-geth
+    clone_into heart-monitor         nibi-go-hm
+    clone_into ts-sdk                nibi-ts-sdk
+    clone_into web-app               sai-website
+    clone_into sai-perps             sai-perps
+    clone_into sai-keeper            sai-keeper
+    clone_into sai-docs              sai-docs
+    clone_into iac                   nibi-iac
+  )
+}
+```
+
+Then **`clone_nibiruchain_ki`**.
+
+## Remote check (one-liner)
+
+```bash
+for d in nibi-chain nibi-geth nibi-go-hm nibi-ts-sdk sai-website sai-perps sai-keeper sai-docs nibi-iac; do
+  printf '%s: ' "$d"
+  git -C "$HOME/ki/$d" remote get-url origin 2>/dev/null || echo "(missing)"
+done
+```

--- a/ai-skills/sai-perps-query/SKILL.md
+++ b/ai-skills/sai-perps-query/SKILL.md
@@ -2,7 +2,7 @@
 name: sai-perps-query
 description: >-
   Run read-only queries against Sai mainnet CosmWasm contracts (Perp, Oracle,
-  Vault) using Nibiru CLI (nibid) or the Nibiru TypeScript SDK. Use when the user
+  SLP Vault) using Nibiru CLI (nibid) or the Nibiru TypeScript SDK. Use when the user
   asks to query Sai perp contracts, inspect open interest, check OI limits, look up
   MarketIndex/TokenIndex/GroupIndex, run get_borrowing_group_oi or
   get_borrowing_pair_oi, call queryContractSmart, or inspect Sai markets and
@@ -26,10 +26,10 @@ Full validated CLI notes: `$HOME/ki/boku/epics/epic-sai/26-02-10-sai-mainnet-que
 |----------|---------|
 | **Perp** | `nibi1ntmw2dfvd0qnw5fnwdu9pev2hsnqfdj9ny9n0nzh2a5u8v0scflq930mph` |
 | **Oracle** | `nibi1xfwyfwtdame6645lgcs4xvf4u0hpsuvxrcelfwtztu0pv7n4l6hqw5a8gj` |
-| Vault — Group 0 / USDC | `nibi193m2a00pmdsvkcvugrfewqzhtq6k0srkjzvxp2sk357vlpspx5vqxu8d7p` |
-| Vault — Group 0 / stNIBI | `nibi1mrplvu3scplnrgns96kg0j8pk3l2p9c7eaz0qdedx0kt3vmcujyqrjkfej` |
-| Vault — Group 1 / USDC | `nibi1waf5c8z55qvjay4de8wkm9cxyt6wa8zdnrvlexjrq77lqgqf258q3yn7l8` |
-| Vault — Group 1 / stNIBI | `nibi1pgurgas0za436c3fm2km99zkzutfx0jwpn7meespv6szv8c8g39qjz2tvj` |
+| SLP-USDC Vault — Group 0 | `nibi193m2a00pmdsvkcvugrfewqzhtq6k0srkjzvxp2sk357vlpspx5vqxu8d7p` |
+| SLP-stNIBI Vault — Group 0 | `nibi1mrplvu3scplnrgns96kg0j8pk3l2p9c7eaz0qdedx0kt3vmcujyqrjkfej` |
+| SLP-USDC Vault — Group 1 | `nibi1waf5c8z55qvjay4de8wkm9cxyt6wa8zdnrvlexjrq77lqgqf258q3yn7l8` |
+| SLP-stNIBI Vault — Group 1 | `nibi1pgurgas0za436c3fm2km99zkzutfx0jwpn7meespv6szv8c8g39qjz2tvj` |
 
 Source: `$HOME/ki/sai-website/webapp/config/env.ts` (`SaiContractsMainnet`).
 
@@ -45,15 +45,18 @@ queries.
 GraphQL reads from this DB. Use when you need schema details, migrations info, to debug indexer logic, or to design and edit queries over indexed data.
 - `sai-rest-api`: Broad interface for aggregated stats, yield. For quick metric
 inspection on different dates.
+- `nibiru-cli-nibid`: Use to run the actual `nibid query wasm contract-state <raw|smart>`
+  commands, configure nodes, inspect keys/config, and query transactions. This
+  skill provides Sai-specific contract addresses and query payloads; the Nibiru
+  CLI skill provides the execution mechanics.
 
 ## CLI setup
 
 ```bash
 PERP="nibi1ntmw2dfvd0qnw5fnwdu9pev2hsnqfdj9ny9n0nzh2a5u8v0scflq930mph"
 ORACLE="nibi1xfwyfwtdame6645lgcs4xvf4u0hpsuvxrcelfwtztu0pv7n4l6hqw5a8gj"
-NODE="https://rpc.archive.nibiru.fi:443"
 # helper alias
-sai_perps_q() { nibid query wasm contract-state smart "$1" "$2" --node "$NODE" --output json; }
+sai_perps_q() { nibid query wasm contract-state smart "$1" "$2"; }
 ```
 
 ## Rules of thumb
@@ -145,7 +148,12 @@ Recorded mainnet snapshot (Group 0 + USDC): pair max = 10,000,000 USDC, group ma
 
 Query message JSON templates, organized by contract. Source: `easy.tsx` `QUERY_CONFIG`.
 
-### Perp contract
+## Perp contract
+
+Below are smart query request payloads for the Sai perp contract. 
+You can use the `/nibiru-cli-nibid` skill to pull any of this information.
+
+- Source: sai-perps repo contracts/perp for the Rust logic
 
 ```json
 {"list_markets":{}}
@@ -183,7 +191,76 @@ Query message JSON templates, organized by contract. Source: `easy.tsx` `QUERY_C
 {"list_user_deposits":{"user":"nibi1..."}}
 ```
 
-### Oracle contract
+## SLP Vault contract
+
+For SLP Vault operations, health accounting, reward distribution, raw state keys,
+and mainnet runbooks, see [slp-vaults.md](./slp-vaults.md).
+
+You can use the `/nibiru-cli-nibid` skill to pull any of this information.
+
+- Source: sai-perps repo contracts/vault for the Rust logic
+
+### SLP Vault Smart Queries
+
+- `{"tvl":{}}` - Notional SLP Vault value using total supply and 
+  `1 + acc_rewards_per_token`. Returns a `Uint128` collateral base-unit amount.
+- `{"available_assets":{}}` - Current accounting value available at 
+  `share_to_assets_price`. Returns a `Uint128` collateral base-unit amount.
+- `{"market_cap":{}}` - SLP share market-cap style value, 
+  `total_supply * share_to_assets_price`. Returns a `Uint128` collateral base-unit amount.
+- `{"current_epoch":{}}` - Current SLP Vault epoch number. Returns a `u64`.
+- `{"get_current_epoch_start":{}}` - Current epoch start timestamp. 
+  Returns a `Timestamp` encoded as a nanosecond string in JSON.
+- `{"config":{}}` - SLP Vault addresses and risk parameters. 
+  Returns `ConfigResponse` with manager/admin addresses, perp/oracle/feed
+  addresses, PnL limits, daily supply cap, discount params, withdrawal thresholds,
+  and `min_lock_duration`.
+- `{"vault_snapshot":{}}` - One-call operator health snapshot. Returns
+  `VaultSnapshotResponse` with `tvl`, `market_cap`, `share_price`,
+  `collateralization_p`, `total_supply`, `total_liability`, `total_rewards`,
+  `epoch`, and `epoch_start`.
+- `{"get_revenue_info":{}}` - Revenue and PnL accounting summary. 
+  Returns `RevenueInfo` with `net_profit`, `rewards`, `closed_pnl`, `liabilities`, and `current_epoch_positive_open_pnl`.
+- `{"collateralization_p":{}}` - Policy health ratio for the SLP Vault. 
+  Returns a `Decimal`; values below `1.0` mean the SLP Vault is below target by contract accounting.
+- `{"withdraw_epochs_timelock":{}}` - Number of epochs a new withdrawal request
+  must wait at current collateralization. Returns a `u64`.
+- `{"get_vault_share_denom":{}}` - Native denom for the SLP share token. Returns
+  a `String`.
+- `{"get_collateral_denom":{}}` - Native collateral denom accepted by the SLP
+  Vault. Returns a `String`.
+- `{"max_mint":{}}` - Maximum SLP shares that can be minted right now under the
+  supply cap. Returns a `Uint128` share base-unit amount, or `u128::MAX` when
+  uncapped.
+- `{"max_deposit":{}}` - Maximum collateral that can be deposited right now.
+  Returns a `Uint128` collateral base-unit amount, or `u128::MAX` when uncapped.
+- `{"max_redeem":{"depositor":"nibi1..."}}` - Maximum SLP shares a depositor can
+  currently redeem from matured withdrawal requests. Returns a `Uint128` share
+  base-unit amount.
+- `{"max_withdraw":{"depositor":"nibi1..."}}` - Maximum collateral a depositor
+  can currently withdraw from matured withdrawal requests. Returns a `Uint128`
+  collateral base-unit amount.
+- `{"total_shares_being_withdrawn":{"depositor":"nibi1..."}}` - Total SLP shares
+  currently recorded in withdrawal requests for a depositor. Returns a `Uint128`
+  share base-unit amount.
+- `{"user_withdraw_requests":{"user":"nibi1..."}}` - Withdrawal requests for a
+  user. Returns `UserWithdrawRequestsResponse` with `requests: [{ shares, unlock_epoch, auto_redeem }]`.
+- `{"get_locked_deposit":{"deposit_id":0}}` - Locked deposit details by ID.
+  Returns `LockedDeposit` with depositor, shares, deposited assets, discount,
+  timestamp, and lock duration.
+- `{"all_locked_deposits":{"start_after":null,"limit":null}}` - Paginated locked 
+  deposit list. Returns `locked_deposits: [(deposit_id, LockedDeposit)]` (type
+`AllLockedDepositsResponse`)
+- `{"user_locked_deposits":{"user":"nibi1..."}}` - Locked deposits owned by a user. Returns `UserLockedDepositsResponse` with `locked_deposits: [(deposit_id, LockedDeposit)]`.
+- `{"lock_discount_p":{"collat_p":"1.0","lock_duration":0}}` - Simulated lock discount for a collateralization ratio and lock duration. Returns a `Decimal` discount percentage.
+- `{"user_vault_state":{"user":"nibi1..."}}` - User-level SLP Vault state bundle. Returns `UserVaultStateResponse` with share balance, estimated assets, pending withdrawals, locked deposits, and max redeem/withdraw values.
+
+## Oracle contract
+
+Below are smart query request payloads for the Sai oracle contract.
+You can use the `/nibiru-cli-nibid` skill to pull any of this information.
+
+- Source: sai-perps repo contracts/oracle for the Rust logic
 
 ```json
 {"list_tokens":{"start_after":null,"limit":null}}
@@ -195,34 +272,6 @@ Query message JSON templates, organized by contract. Source: `easy.tsx` `QUERY_C
 {"list_permission_groups":{"start_after":null,"limit":null}}
 {"expiration_time":{}}
 {"ownership":{}}
-```
-
-### Vault contract
-
-```json
-{"tvl":{}}
-{"available_assets":{}}
-{"market_cap":{}}
-{"current_epoch":{}}
-{"get_current_epoch_start":{}}
-{"config":{}}
-{"vault_snapshot":{}}
-{"get_revenue_info":{}}
-{"collateralization_p":{}}
-{"withdraw_epochs_timelock":{}}
-{"get_vault_share_denom":{}}
-{"get_collateral_denom":{}}
-{"max_mint":{}}
-{"max_deposit":{}}
-{"max_redeem":{"depositor":"nibi1..."}}
-{"max_withdraw":{"depositor":"nibi1..."}}
-{"total_shares_being_withdrawn":{"depositor":"nibi1..."}}
-{"user_withdraw_requests":{"user":"nibi1..."}}
-{"get_locked_deposit":{"deposit_id":0}}
-{"all_locked_deposits":{"start_after":null,"limit":null}}
-{"user_locked_deposits":{"user":"nibi1..."}}
-{"lock_discount_p":{"collat_p":"1.0","lock_duration":0}}
-{"user_vault_state":{"user":"nibi1..."}}
 ```
 
 ## TypeScript (NibiruQuerier) alternative

--- a/ai-skills/sai-perps-query/reference.md
+++ b/ai-skills/sai-perps-query/reference.md
@@ -18,10 +18,10 @@ This file is the **full lookup** companion to `SKILL.md`.
 |---|---|
 | **Perp** | `nibi1ntmw2dfvd0qnw5fnwdu9pev2hsnqfdj9ny9n0nzh2a5u8v0scflq930mph` |
 | **Oracle** | `nibi1xfwyfwtdame6645lgcs4xvf4u0hpsuvxrcelfwtztu0pv7n4l6hqw5a8gj` |
-| SLP-USDC Vault, Group 0. | `nibi193m2a00pmdsvkcvugrfewqzhtq6k0srkjzvxp2sk357vlpspx5vqxu8d7p` |
-| SLP-stNIBI Vault, Group 0. | `nibi1mrplvu3scplnrgns96kg0j8pk3l2p9c7eaz0qdedx0kt3vmcujyqrjkfej` |
+| SLP-USDC Vault, Group 0 | `nibi193m2a00pmdsvkcvugrfewqzhtq6k0srkjzvxp2sk357vlpspx5vqxu8d7p` |
+| SLP-stNIBI Vault, Group 0 | `nibi1mrplvu3scplnrgns96kg0j8pk3l2p9c7eaz0qdedx0kt3vmcujyqrjkfej` |
 | SLP-USDC Vault, Group 1 | `nibi1waf5c8z55qvjay4de8wkm9cxyt6wa8zdnrvlexjrq77lqgqf258q3yn7l8` |
-| SLP-stNIBI Vault, Group 1. | `nibi1pgurgas0za436c3fm2km99zkzutfx0jwpn7meespv6szv8c8g39qjz2tvj` |
+| SLP-stNIBI Vault, Group 1 | `nibi1pgurgas0za436c3fm2km99zkzutfx0jwpn7meespv6szv8c8g39qjz2tvj` |
 
 **Group meanings (Perp `GroupIndex`):**
 - `GroupIndex(0)` = main crypto markets

--- a/ai-skills/sai-perps-query/slp-vaults.md
+++ b/ai-skills/sai-perps-query/slp-vaults.md
@@ -1,0 +1,401 @@
+# Sai SLP Vaults Query Reference
+
+Use this reference when inspecting Sai SLP Vault health, deposit caps, rewards,
+or raw SLP Vault accounting state on Nibiru mainnet.
+
+## Mainnet SLP Vault Addresses
+
+| SLP Vault | Address |
+| --- | --- |
+| SLP-USDC Vault — Group 0 | `nibi193m2a00pmdsvkcvugrfewqzhtq6k0srkjzvxp2sk357vlpspx5vqxu8d7p` |
+| SLP-stNIBI Vault — Group 0 | `nibi1mrplvu3scplnrgns96kg0j8pk3l2p9c7eaz0qdedx0kt3vmcujyqrjkfej` |
+| SLP-USDC Vault — Group 1 | `nibi1waf5c8z55qvjay4de8wkm9cxyt6wa8zdnrvlexjrq77lqgqf258q3yn7l8` |
+| SLP-stNIBI Vault — Group 1 | `nibi1pgurgas0za436c3fm2km99zkzutfx0jwpn7meespv6szv8c8g39qjz2tvj` |
+
+Group 0 is the main crypto market group. Group 1 is the real-estate / Coded
+Estate group. USDC and stNIBI both use 6 decimal base units on Sai.
+
+## Setup
+
+Use the `/nibiru-cli-nibid` skill since this behavior relies heavily on using the
+CLI properly.
+
+```bash
+PERP="nibi1ntmw2dfvd0qnw5fnwdu9pev2hsnqfdj9ny9n0nzh2a5u8v0scflq930mph"
+VAULT_G0_USDC="nibi193m2a00pmdsvkcvugrfewqzhtq6k0srkjzvxp2sk357vlpspx5vqxu8d7p"
+VAULT_G0_STNIBI="nibi1mrplvu3scplnrgns96kg0j8pk3l2p9c7eaz0qdedx0kt3vmcujyqrjkfej"
+VAULT_G1_USDC="nibi1waf5c8z55qvjay4de8wkm9cxyt6wa8zdnrvlexjrq77lqgqf258q3yn7l8"
+VAULT_G1_STNIBI="nibi1pgurgas0za436c3fm2km99zkzutfx0jwpn7meespv6szv8c8g39qjz2tvj"
+
+sai_q() {
+  nibid query wasm contract-state smart "$1" "$2" --output json
+}
+
+raw_item() {
+  contract="$1"
+  key="$2"
+  hex=$(printf '%s' "$key" | xxd -p -c 256)
+  nibid query wasm contract-state raw "$contract" "$hex" \
+    --output json | jq -r '.data // empty' | base64 -d
+  echo
+}
+```
+
+## SLP Vault State Overview
+
+This section defines the SLP Vault terms and storage values used in health,
+deposit-cap, reward, and raw-state investigations. Use smart queries for the
+normal operator view, and raw state only when validating exact storage items or
+debugging query surfaces.
+
+### Core Terms
+
+| Term | Meaning | Where to query |
+| --- | --- | --- |
+| Collateral | The asset deposited into an SLP Vault, such as USDC or stNIBI. Amounts are stored in base units; USDC and stNIBI use 6 decimals. | `{"get_collateral_denom":{}}`, perp `{"get_collateral":{"index":1}}` |
+| SLP shares | The receipt/share token minted to LPs. Shares represent a pro-rata claim on SLP Vault accounting value. | `{"get_vault_share_denom":{}}`, `{"vault_snapshot":{}}` |
+| Total supply | Total SLP shares outstanding, in base share units. This is queried through the SLP Vault token minter and surfaced in `vault_snapshot`. | `{"vault_snapshot":{}}` |
+| Share price | Collateral per SLP share, stored as `share_to_assets_price`. Deposits mint `assets / share_price`; redemptions return `shares * share_price`. | `{"vault_snapshot":{}}`, raw `share_to_assets_price` |
+| Collateralization | Policy health ratio. When `acc_pnl_per_token_used` is positive, it is approximately `(1 + acc_rewards_per_token - acc_pnl_per_token_used) / (1 + acc_rewards_per_token)`. Values below `1.0` mean the SLP Vault is below target by contract accounting. | `{"collateralization_p":{}}`, `{"vault_snapshot":{}}` |
+| TVL | Notional SLP Vault value using total supply and `1 + acc_rewards_per_token`. It is not the same as immediately available collateral. | `{"tvl":{}}` |
+| Market cap / available assets | Current redeemable/accounting value using total supply and `share_to_assets_price`. These queries currently return the same value. | `{"market_cap":{}}`, `{"available_assets":{}}` |
+| Net profit | Derived operator metric: `total_rewards - total_closed_pnl - total_liability + current_epoch_positive_open_pnl`. Negative values indicate the SLP Vault is underwater by this accounting view. | `{"get_revenue_info":{}}` |
+
+### Health and PnL State
+
+These variables explain why an SLP Vault is healthy or stressed. They are the
+main raw items to check when `collateralization_p`, `share_price`, or deposit
+caps look surprising.
+
+| Raw key | Definition | Smart-query surface |
+| --- | --- | --- |
+| `acc_rewards_per_token` | Per-share reward accumulator. It increases when `distribute_reward` is executed with the SLP Vault's collateral. Raising this improves `share_price` and can improve `collateralization_p`. | `{"vault_snapshot":{}}`, `{"get_revenue_info":{}}` |
+| `acc_pnl_per_token` | Raw cumulative PnL per share. This tracks realized and feed-driven PnL at the accounting layer. | Raw state; indirectly reflected in health/revenue queries |
+| `acc_pnl_per_token_used` | Policy-applied PnL per share. This is the main stress value for `collateralization_p` and the deposit cap. If it is positive, the SLP Vault is carrying used trader profit / liability pressure. | `{"collateralization_p":{}}`, raw state |
+| `share_to_assets_price` | Current collateral-per-share price used for minting and redeeming. It is recomputed from rewards and used PnL. | `{"vault_snapshot":{}}`, `{"market_cap":{}}`, raw state |
+| `total_rewards` | Cumulative collateral distributed as SLP Vault rewards through `distribute_reward`. This is historical/accounted rewards, not a pending reward queue. | `{"get_revenue_info":{}}`, `{"vault_snapshot":{}}` |
+| `total_closed_pnl` | Cumulative realized trader PnL from closed trades. Positive values mean the SLP Vault has paid trader profits net of received losses. | `{"get_revenue_info":{}}`, raw state |
+| `total_liability` | Total tracked SLP Vault obligations. Higher liability worsens `net_profit`. | `{"get_revenue_info":{}}`, `{"vault_snapshot":{}}` |
+| `current_epoch_positive_open_pnl` | Positive open trader PnL tracked for the current epoch. It is used by `get_revenue_info` and epoch accounting. | `{"get_revenue_info":{}}`, raw state |
+
+Query the operator view:
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"vault_snapshot":{}}'
+sai_q "$VAULT_G0_USDC" '{"get_revenue_info":{}}'
+sai_q "$VAULT_G0_USDC" '{"collateralization_p":{}}'
+```
+
+Query the backing raw items:
+
+```bash
+for key in \
+  acc_rewards_per_token \
+  acc_pnl_per_token \
+  acc_pnl_per_token_used \
+  share_to_assets_price \
+  total_rewards \
+  total_closed_pnl \
+  total_liability \
+  current_epoch_positive_open_pnl
+do
+  raw_item "$VAULT_G0_USDC" "$key"
+done
+```
+
+### Deposit Cap State
+
+Large SLP deposits can fail even when the user has enough collateral. The cap is
+active when `acc_pnl_per_token_used > 0`. In that state, the SLP Vault limits new
+share minting to the remaining headroom under `current_max_supply`.
+
+| Raw key / config field | Definition | Where to query |
+| --- | --- | --- |
+| `current_max_supply` | Current maximum allowed SLP share supply while the cap is active. Remaining mint headroom is `current_max_supply - total_supply`, floored at zero. | Raw state; effect surfaced through `{"max_mint":{}}` |
+| `last_max_supply_update` | Timestamp of the last `current_max_supply` refresh. The refresh is gated to at most once every 86,400 seconds on eligible SLP Vault flows. | Raw state |
+| `max_supply_increase_daily_p` | Configured daily supply growth percentage. New cap is `total_supply * (1 + max_supply_increase_daily_p)` when the refresh runs. | `{"config":{}}` |
+| `max_mint` | Derived maximum number of SLP shares that can be minted right now. Returns `u128::MAX` when the cap is effectively off. | `{"max_mint":{}}` |
+| `max_deposit` | Derived maximum collateral deposit right now, equal to `max_mint` converted through `share_to_assets_price`. | `{"max_deposit":{}}` |
+
+Operator queries:
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"max_deposit":{}}'
+sai_q "$VAULT_G0_USDC" '{"max_mint":{}}'
+sai_q "$VAULT_G0_USDC" '{"config":{}}'
+raw_item "$VAULT_G0_USDC" current_max_supply
+raw_item "$VAULT_G0_USDC" last_max_supply_update
+```
+
+### Epoch and Withdrawal State
+
+Epoch state affects withdrawal request timing and the open/locked window for
+withdrawals. Epoch starts are stored as nanosecond timestamps.
+
+| Raw key / query | Definition | Where to query |
+| --- | --- | --- |
+| `current_epoch` | Current SLP Vault epoch number. | `{"current_epoch":{}}`, raw state |
+| `current_epoch_start` | Timestamp when the current epoch started. | `{"get_current_epoch_start":{}}`, raw state |
+| `withdraw_lock_thresholds_p` | Collateralization bands that determine whether withdrawals wait 1, 2, or 3 epochs. | `{"config":{}}` |
+| `withdraw_epochs_timelock` | Derived number of epochs a new withdrawal request must wait at current collateralization. | `{"withdraw_epochs_timelock":{}}` |
+
+Operator queries:
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"current_epoch":{}}'
+sai_q "$VAULT_G0_USDC" '{"get_current_epoch_start":{}}'
+sai_q "$VAULT_G0_USDC" '{"withdraw_epochs_timelock":{}}'
+sai_q "$VAULT_G0_USDC" '{"config":{}}'
+```
+
+### Reward Funding State
+
+There is no separate pending SLP Vault reward queue. Rewards become SLP Vault
+accounting only when collateral is sent with `{"distribute_reward":{}}`.
+
+| State | Definition | Where to query |
+| --- | --- | --- |
+| `total_rewards` | Cumulative rewards already distributed to the SLP Vault. | `{"get_revenue_info":{}}`, raw `total_rewards` |
+| `acc_rewards_per_token` | Per-share form of distributed rewards. | `{"vault_snapshot":{}}`, raw `acc_rewards_per_token` |
+| perp `pending_gov_fees` | Governance fees accrued on the perp contract by collateral. These are not SLP Vault rewards until claimed and explicitly distributed to an SLP Vault. | perp `{"get_pending_gov_fees":{"index":1}}`, raw perp map |
+| `vault_closing_fee_p` | Perp config that controls what portion of closing fees routes directly to the SLP Vault reward path during trading. | perp fee/config queries or raw state |
+| `vault_addresses` | Perp map from `(GroupIndex, TokenIndex)` to target SLP Vault address. | perp `{"get_vault_address":{...}}` |
+
+Operator queries:
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"get_revenue_info":{}}'
+sai_q "$PERP" '{"get_pending_gov_fees":{"index":1}}' # USDC
+sai_q "$PERP" '{"get_pending_gov_fees":{"index":2}}' # stNIBI
+sai_q "$PERP" '{"get_vault_address":{"group_index":"GroupIndex(0)","collateral_index":"TokenIndex(1)"}}'
+```
+
+### Config and Denom State
+
+Use these values to interpret units, risk limits, and which collateral must be
+attached to executes.
+
+| Key / field | Definition | Where to query |
+| --- | --- | --- |
+| `collateral_denom` | Native denom accepted by the SLP Vault for deposits and `distribute_reward`. | `{"get_collateral_denom":{}}` |
+| `vault_denom` | Native denom of the SLP share token. | `{"get_vault_share_denom":{}}` |
+| `vault_token_minter_contract` | Contract queried for total SLP share supply and used to mint/burn SLP shares. | raw state or config/source |
+| `max_daily_acc_pnl_delta` | Daily throttle on positive realized PnL payout accounting. | `{"config":{}}` |
+| `max_acc_open_pnl_delta` | Cap applied to positive open PnL updates per epoch. | `{"config":{}}` |
+| `losses_burn_p` | Portion of incoming trader-loss assets reserved for deficit recovery under specific negative-PnL conditions. | `{"config":{}}` |
+| `max_discount_p` | Maximum locked-deposit bonus/discount. | `{"config":{}}` |
+| `max_discount_threshold_p` | Collateralization threshold where locked-deposit bonus phases out. | `{"config":{}}` |
+| `min_lock_duration` | Minimum lock duration accepted for locked deposits. | `{"config":{}}` |
+
+Operator queries:
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"config":{}}'
+sai_q "$VAULT_G0_USDC" '{"get_collateral_denom":{}}'
+sai_q "$VAULT_G0_USDC" '{"get_vault_share_denom":{}}'
+```
+
+## Health Snapshot
+
+Start here when diagnosing whether an SLP Vault is healthy or why LP deposits are
+blocked.
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"vault_snapshot":{}}'
+sai_q "$VAULT_G0_USDC" '{"get_revenue_info":{}}'
+sai_q "$VAULT_G0_USDC" '{"collateralization_p":{}}'
+sai_q "$VAULT_G0_USDC" '{"available_assets":{}}'
+sai_q "$VAULT_G0_USDC" '{"market_cap":{}}'
+sai_q "$VAULT_G0_USDC" '{"tvl":{}}'
+```
+
+Important fields:
+
+- `collateralization_p`: Policy health ratio. Values below `1.0` mean the SLP Vault
+  is under target by the contract's accounting.
+- `share_price`: Current collateral-per-share price used for mint/redeem.
+- `total_supply`: Total SLP share supply in base share units.
+- `total_liability`: SLP Vault obligations tracked by the contract.
+- `total_rewards`: Rewards already distributed through `DistributeReward`.
+- `current_epoch_positive_open_pnl`: Positive open PnL tracked for the current
+  epoch.
+
+`get_revenue_info` computes:
+
+```text
+net_profit = rewards - closed_pnl - liabilities + current_epoch_positive_open_pnl
+```
+
+## Deposit Caps
+
+Use these when users report that large SLP deposits are failing.
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"max_deposit":{}}'
+sai_q "$VAULT_G0_USDC" '{"max_mint":{}}'
+sai_q "$VAULT_G0_USDC" '{"config":{}}'
+```
+
+`max_deposit` is returned in collateral base units. For USDC and stNIBI, divide
+by `1e6` for human units.
+
+When `acc_pnl_per_token_used > 0`, deposits are capped by remaining mint
+headroom under `current_max_supply`. `current_max_supply` is refreshed at most
+once per 86,400 seconds on eligible SLP Vault flows and uses:
+
+```text
+current_max_supply = total_supply * (1 + max_supply_increase_daily_p)
+```
+
+When `acc_pnl_per_token_used <= 0`, `max_mint` and `max_deposit` return
+`u128::MAX`, meaning this cap is effectively off.
+
+## Rewards and Collateralization
+
+Do not plain-send collateral to the SLP Vault address when trying to improve health.
+A bank transfer can increase the contract's balance, but it will not update
+SLP Vault accounting.
+
+To intentionally increase `acc_rewards_per_token`, `total_rewards`,
+`share_price`, and `collateralization_p`, execute `distribute_reward` with the
+SLP Vault's collateral denom:
+
+```bash
+USDC_DENOM="erc20/0x0829F361A05D993d5CEb035cA6DF3446b060970b"
+
+nibid tx wasm execute "$VAULT_G0_USDC" \
+  '{"distribute_reward":{}}' \
+  --amount "1000000000$USDC_DENOM" \
+  --from <your-key> \
+  --gas 300000
+```
+
+The example above distributes `1,000` USDC to all SLP holders. This does not mint
+new shares. It raises the per-share reward accumulator.
+
+To estimate the reward needed for a target collateralization:
+
+```text
+max = 1 + acc_rewards_per_token
+used = acc_pnl_per_token_used
+collateralization_p = (max - used) / max
+
+target_reward_per_share = used / (1 - target_collateralization_p) - max
+target_reward_amount = target_reward_per_share * total_supply
+```
+
+This formula assumes `acc_pnl_per_token_used` is positive.
+
+## Pending Governance Fees
+
+Perp-side `pending_gov_fees` are not automatically SLP rewards. They are
+admin-controlled accounting on the perp contract. The admin can claim them to a
+recipient, and ops can then execute `distribute_reward` on the target SLP Vault if
+that is the intended use.
+
+Smart queries:
+
+```bash
+# TokenIndex(1) = USDC, TokenIndex(2) = stNIBI
+sai_q "$PERP" '{"get_pending_gov_fees":{"index":1}}'
+sai_q "$PERP" '{"get_pending_gov_fees":{"index":2}}'
+sai_q "$PERP" '{"get_collateral":{"index":1}}'
+sai_q "$PERP" '{"get_collateral":{"index":2}}'
+```
+
+Do not use `UpdatePendingGovFees` as a funding mechanism. It is an admin state
+update and does not transfer funds into the SLP Vault.
+
+## Raw SLP Vault State
+
+SLP Vault `Item` keys are raw ASCII key hex without a namespace length prefix.
+
+```bash
+raw_item() {
+  contract="$1"
+  key="$2"
+  hex=$(printf '%s' "$key" | xxd -p -c 256)
+  nibid query wasm contract-state raw "$contract" "$hex" \
+    --output json | jq -r '.data // empty' | base64 -d
+  echo
+}
+
+for key in \
+  total_rewards \
+  total_closed_pnl \
+  total_liability \
+  current_epoch_positive_open_pnl \
+  acc_rewards_per_token \
+  acc_pnl_per_token \
+  acc_pnl_per_token_used \
+  share_to_assets_price
+do
+  echo "=== $key ==="
+  raw_item "$VAULT_G0_USDC" "$key"
+done
+```
+
+Useful raw keys:
+
+| Key | Meaning |
+| --- | --- |
+| `total_rewards` | Cumulative rewards distributed to the SLP Vault |
+| `total_closed_pnl` | Cumulative realized trader PnL paid/received |
+| `total_liability` | Total tracked SLP Vault obligations |
+| `current_epoch_positive_open_pnl` | Positive open PnL for current epoch |
+| `acc_rewards_per_token` | Per-share reward accumulator |
+| `acc_pnl_per_token` | Raw cumulative PnL per share |
+| `acc_pnl_per_token_used` | Policy-applied PnL per share |
+| `share_to_assets_price` | Collateral per share for mint/redeem |
+
+## Raw Pending Gov Fees
+
+`PENDING_GOV_FEES` is a perp contract map:
+
+```rust
+Map<TokenIndex, Uint128>::new("pending_gov_fees")
+```
+
+`TokenIndex` is a two-byte big-endian `u16`. For a single-key map, use:
+
+```text
+len(namespace) || namespace || token_index_be_u16
+```
+
+Raw query helper:
+
+```bash
+raw_pending_gov_fees() {
+  idx="$1"
+  ns="pending_gov_fees"
+  ns_hex=$(printf '%s' "$ns" | xxd -p -c 256)
+  ns_len_hex=$(printf '%04x' "${#ns}")
+  idx_hex=$(printf '%04x' "$idx")
+  hex_key="${ns_len_hex}${ns_hex}${idx_hex}"
+
+  nibid query wasm contract-state raw "$PERP" "$hex_key" \
+    --output json | jq -r '.data // empty' | base64 -d
+  echo
+}
+
+raw_pending_gov_fees 1 # USDC
+raw_pending_gov_fees 2 # stNIBI
+```
+
+## Epoch and Withdrawal Timing
+
+```bash
+sai_q "$VAULT_G0_USDC" '{"current_epoch":{}}'
+sai_q "$VAULT_G0_USDC" '{"get_current_epoch_start":{}}'
+sai_q "$VAULT_G0_USDC" '{"withdraw_epochs_timelock":{}}'
+```
+
+Epoch start is a `Timestamp` nanosecond value. Convert with:
+
+```bash
+python3 - <<'PY'
+from datetime import datetime, timezone
+ns = 1778544218237604327
+print(datetime.fromtimestamp(ns / 1e9, tz=timezone.utc))
+PY
+```

--- a/ai-skills/skill-creator/LICENSE.md
+++ b/ai-skills/skill-creator/LICENSE.md
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Unique Divine.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ai-skills/skill-creator/SKILL.md
+++ b/ai-skills/skill-creator/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and run lightweight review loops. Use when users want to create a skill from scratch, edit an existing skill, try realistic test prompts, or improve when and how a skill should trigger.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few realistic test prompts and run them with the skill
+- Help the user review the results qualitatively, with simple objective checks
+  when the task has clear pass/fail requirements
+- Rewrite the skill based on feedback from those examples
+- Repeat until you're satisfied
+- Expand the test set only when the skill is important enough to justify it
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test prompts, decide how they want to review the outputs, run the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to trying it on a few realistic prompts and improving from there.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of tests, just vibe with me", you can do that instead.
+
+Then after the skill is done, you can help tune the skill description so it
+triggers in the right situations. Keep this lightweight unless the user
+explicitly asks for a deeper review loop.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. Some users may be comfortable editing JSON and running scripts; others may just want help turning a repeated workflow into clear instructions. Pay attention to context cues and adjust your language.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" is borderline, but OK; "test prompt" or "review" is often clearer
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable the agent to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Agents often underuse skills when the description is too narrow, so make descriptions specific and a little proactive. For instance, instead of "How to build a simple fast dashboard to display internal data.", you might write "Build simple fast dashboards for internal metrics, data visualization, CSV summaries, and company reporting, even when the user does not explicitly say 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+├── SKILL.md (workflow + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+The agent reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Prompts
+
+After writing the skill draft, come up with 2-3 realistic test prompts — the
+kind of thing a real user would actually say. Share them with the user: [you
+don't have to use this exact language] "Here are a few test cases I'd like to
+try. Do these look right, or do you want to add more?" Then run them if the
+user wants a concrete check.
+
+For most skill edits, keep the prompts in the conversation. If the skill is
+likely to be reused or iterated on, save a short `test-prompts.md` beside the
+skill with the prompt, expected result, and any input files.
+
+## Running and reviewing test prompts
+
+Keep the review loop lightweight by default. The goal is to learn whether the
+skill changes behavior in the direction the user wants, not to build a
+measurement harness.
+
+If you save results, put them in `<skill-name>-workspace/` as a sibling to the
+skill directory. Organize results by iteration only if that makes the review
+clearer. Don't create a large folder structure upfront.
+
+### Step 1: Run the prompts
+
+For each test prompt, run one task using the current skill:
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <test prompt>
+- Input files: <test files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/test-<ID>/outputs/
+- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+```
+
+Only run side-by-side comparisons when the user asks for them, or when the
+change is risky enough that comparison would clearly help. Otherwise, keep
+attention on the quality of the current skill's output.
+
+### Step 2: Note simple checks
+
+While runs are in progress, write down any objective checks that matter. Good
+checks are statements a reviewer can verify from the output, such as "the CSV
+contains a `margin_percent` column" or "the answer cites the source file." Avoid
+forcing pass/fail checks onto subjective work like tone, taste, or strategy.
+
+### Step 3: Review with the user
+
+When outputs are ready, show them to the user in the most convenient format:
+
+- For a few plain-text outputs, summarize them in the conversation and ask what
+  should change.
+- For file outputs or several test prompts, point the user to the result paths
+  and summarize what changed.
+- If you wrote objective checks, grade them plainly and treat the results as
+  review notes, not as a scorecard.
+
+### Step 4: Read the feedback
+
+When the user gives feedback, focus your improvements on the test cases where
+they had specific complaints. Empty or minimal feedback usually means the output
+was fine enough for that example.
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+Skill improvements should generalize beyond the examples in front of you. Take
+time to understand what the user actually wants, write a draft revision, then
+look at it again with fresh eyes before calling it done.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun the useful test prompts into a new `iteration-<N+1>/` directory
+3. Wait for the user to review and tell you what's still off
+4. Improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Description Tuning
+
+The description field in `SKILL.md` frontmatter is the primary mechanism that
+helps an agent decide whether the skill is relevant. After creating or improving
+a skill, offer to tune the description for better triggering accuracy.
+
+### Step 1: Generate trigger examples
+
+Create a set of trigger examples — a mix of should-trigger and
+should-not-trigger. Plain bullets are enough:
+
+- Should trigger: "the user prompt"
+- Should not trigger: "a nearby prompt that should use a different skill"
+
+The queries must be realistic and something a user would actually type. Not
+abstract requests, but requests that are concrete and specific and have a good
+amount of detail. For instance, file paths, personal context about the user's job
+or situation, column names and values, company names, URLs. A little bit of
+backstory. Some might be in lowercase or contain abbreviations or typos or casual
+speech. Use a mix of different lengths, and focus on edge cases rather than
+making them clear-cut.
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with the user
+
+Show the trigger examples to the user and ask whether the boundaries look right.
+This step matters because bad trigger examples lead to bad descriptions.
+
+### Step 3: Revise the description
+
+Use the reviewed examples to revise the description by hand. Aim for:
+
+- Clear should-trigger contexts
+- A few near-miss phrases the description should avoid overclaiming
+- Specific nouns and workflows users actually mention
+- No dependency on product-specific terminology unless the skill is truly tied
+  to that product
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better examples. Skills are
+usually advertised to the agent through their name and description. The important
+thing to know is that agents may skip skills for simple one-step tasks they can
+handle directly. Complex, multi-step, or specialized queries are more likely to
+trigger a skill when the description matches.
+
+This means your trigger examples should be substantive enough that the agent
+would actually benefit from consulting a skill. Simple queries like "read file X"
+are poor examples.
+
+### Step 4: Apply the result
+
+Update the skill's `SKILL.md` frontmatter. Show the user the before/after and
+explain why the new version should trigger better.
+
+---
+
+### Validate
+
+If you need a quick structural check, run `scripts/quick_validate.py` against the
+skill directory. This only validates `SKILL.md` frontmatter; it does not judge
+whether the skill is useful.
+
+---
+
+## Environment Notes
+
+The core workflow is the same across environments: draft → test prompt → review
+with the user → improve → repeat. Adapt the mechanics to whatever the current
+environment can do.
+
+**Running test cases**: If subagents or background agents are available, use them
+for independent test runs. If not, run the prompts yourself one at a time. The
+human review step matters more than strict isolation.
+
+**Reviewing results**: Present results directly in the conversation. For each
+test case, show the prompt and the output summary. If the output is a file the
+user needs to inspect, save it to the filesystem and point to the path.
+
+**The iteration loop**: Same as before — improve the skill, rerun the useful test
+prompts, ask for feedback. You can still organize results into iteration
+directories on the filesystem if helpful.
+
+**Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+- **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
+- **If creating a distributable file manually, stage in `/tmp/` first**, then
+  copy to the output directory -- direct writes may fail due to permissions.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run realistic test prompts with the skill
+- Review the outputs with the user
+- Repeat until you and the user are satisfied
+- Leave the final skill in place for the user to review.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you
+don't forget.
+
+Good luck!

--- a/ai-skills/skill-creator/TODO.md
+++ b/ai-skills/skill-creator/TODO.md
@@ -1,0 +1,22 @@
+# skill-creator — follow-ups
+
+Open items while this skill settles after the slim-down.
+
+## Tooling / scripts
+
+- [ ] Document when and how to run `scripts/quick_validate.py`, including exact
+      command (`python …/quick_validate.py <skill_dir>`).
+- [ ] Resolve the PyYAML dependency smell (either document `pip install pyyaml`,
+      switch to slice + `yq`, or rewrite validation).
+- [ ] Decide whether `scripts/utils.py` stays for skill authors who write their
+      own Python helpers — if yes, add a sentence in `SKILL.md`; if no, drop it.
+
+## Skill content
+
+- [ ] Optionally add source attribution in `LICENSE.md` appendix if you share
+      this fork publicly (derivative of Apache-licensed upstream).
+
+## Derived skills
+
+- [x] Extract Markdown task conventions into `md-tasks` skill (`md-tasks/
+      SKILL.md`).

--- a/ai-skills/skill-creator/scripts/quick_validate.py
+++ b/ai-skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/ai-skills/skill-creator/scripts/utils.py
+++ b/ai-skills/skill-creator/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/ai-skills/writing-tech/SKILL.md
+++ b/ai-skills/writing-tech/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: writing-tech
+description: Improve technical writing for specs, implementation notes, READMEs, engineering references, and agent-authored docs. Use when drafting, editing, reviewing, or polishing technical prose; when the user mentions technical writing, style, clarity, ambiguity, specs, docs, documentation, or Google developer docs; or when docs contain many code symbols, database names, API endpoints, GraphQL schema items, commands, or skills.
+---
+
+# Writing Tech
+
+Use this skill to write and edit clear technical documentation for engineers and
+agents. Prioritize project-specific clarity over generic style rules.
+
+## Core stance
+
+- Write for readers who navigate code, schemas, databases, APIs, commands,
+  services, and operational systems.
+- Make the entity type clear when referring to code-formatted symbols.
+- Be concise, but don't let brevity create ambiguity.
+- Treat these as guidelines, not rigid laws. Depart from them when doing so
+  improves the document.
+
+## Qualify code symbols with entity type
+
+When referencing a named code, data, or tool symbol in prose, include a nominal
+qualifier that identifies what kind of entity it is.
+
+Backticks identify the exact symbol. The surrounding noun tells the reader what
+the symbol is.
+
+Prefer:
+
+- table `stats_perp_by_user`
+- database column `market_id`
+- GraphQL field `volume`
+- GraphQL type `PerpBorrowing`
+- function `Delegation`
+- agent skill `nibiru-cli-nibid`
+- command `just fmt`
+- REST endpoint `GET /dexpal/v1/stats`
+- file `graphql/graph/perp.graphqls`
+- service `StatsRefresher`
+
+Avoid bare references when the entity type is not obvious:
+
+- `stats_perp_by_user` refreshes
+- `Delegation` handles this
+- use `nibiru-cli-nibid`
+- run `just fmt`
+
+Better:
+
+- table `stats_perp_by_user` refreshes
+- function `Delegation` handles this
+- use agent skill `nibiru-cli-nibid`
+- run command `just fmt`
+
+## How strict to be
+
+- Prefer qualifiers on first use in a section, like defining a term or spelling
+  out an abbreviation before using it freely.
+- In specs, lean toward qualifying symbols more often than not.
+- Relax the rule when repeated qualifiers make a paragraph noisy and the entity
+  type is already clear.
+- Use judgment. The goal is unambiguous technical prose, not mechanical
+  repetition.
+- Abbreviations are fine in drafts and working notes: `proc`, `fn`, `func`,
+  `db column`, and `GQL field` are acceptable when they improve flow.
+- If the user asks for a polished style or says not to use abbreviations, prefer
+  fuller labels like SQL procedure, function, database column, and GraphQL field.
+
+## Formatting conventions
+
+- Use code font for exact code-related text: filenames, paths, commands,
+  symbols, class names, method names, database objects, GraphQL objects, API
+  fields, config keys, HTTP methods, and status codes.
+- Use bold for UI elements and run-in labels, not as a substitute for code font.
+- Use sentence case for headings.
+- Use standard American spelling and punctuation.
+- Use serial commas.
+- Avoid underlining except for links.
+
+## Prose conventions
+
+- Prefer active voice. Make clear who or what performs the action.
+- Put conditions, circumstances, or goals before instructions when that helps
+  readers skip irrelevant content.
+- Use present tense for current behavior.
+- Avoid future-tense promises unless distinguishing a future action is necessary.
+- Avoid time-sensitive words like now, new, currently, soon, and as of this
+  writing in durable docs.
+- Avoid excessive claims: best, simplest, fastest, never, always, ensure, and
+  guarantee. Prefer verifiable language.
+- Define domain jargon on first use when the reader might not already know it.
+- Avoid anthropomorphism when literal wording is clearer.
+
+## Editing checklist
+
+When editing technical docs:
+
+1. Identify ambiguous bare code symbols.
+2. Add entity-type qualifiers where they improve clarity.
+3. Check whether the first use in each section is clear enough for a reader who
+   knows the domain but not this exact codepath.
+4. Remove repeated qualifiers when they become noisy.
+5. Verify that exact symbols use code font.
+6. Tighten sentences that rely on vague pronouns such as it, this, that, or they.
+7. Keep examples concrete and domain-specific.
+
+## Reference
+
+Long-form source reference:
+`/home/realu/ki/boku/epics/writing-tech/SKILL.md`
+
+Additional style resources:
+`resources.md`

--- a/ai-skills/writing-tech/resources.md
+++ b/ai-skills/writing-tech/resources.md
@@ -1,0 +1,10 @@
+# Technical Writing Resources
+
+- [Google developer documentation style guide](https://developers.google.com/style)
+- [Divio Documentation System](https://docs.divio.com/documentation-system/introduction/)
+- [Red Hat supplementary style guide for product documentation](https://redhat-documentation.github.io/supplementary-style-guide/)
+- [Apple Style Guide](https://help.apple.com/applestyleguide/)
+- [Microsoft Writing Style Guide](https://docs.microsoft.com/style-guide/welcome/)
+
+Use these references for follow-up research. Project-specific clarity and the
+rules in `SKILL.md` take precedence when they conflict with general guidance.


### PR DESCRIPTION
# Expand ai-skills playbooks and Sai/Epics references
This PR refreshes the Cursor `ai-skills/` tree so agents get clearer operational guidance: new reusable skills for reviews and authoring, richer Epics+ and repo-navigation workflows, and deeper Sai mainnet query docs—while leaning on `nibid` config instead of hard-coded RPC endpoints where examples used to pin archive nodes.
## Key Changes
- **New skills**: `gh-pr-review` (structured PR review), `skill-creator` (authoring loop + `quick_validate` helpers + Apache `LICENSE`), `md-tasks` (checkbox conventions), `writing-tech` (prose/style for agent-facing docs).
- **Epics+**: Quick Start reordering, `repo-map` cross-reference for `repos`, and a dedicated “Finding or Searching for Epics” mode with JSON scan fields, ranking, output shapes, and status/limit flags.
- **Chain/repo tooling**: `nibiru-cli-nibid` documents `get.nibiru.fi` installs; bank send example drops inline archive `--node`; `repo-map` adds NibiruChain remote table and `cloning.md` with `~/ki` clone recipes.
- **Sai perps**: Vault labeling cleanup, expanded SLP smart-query documentation in `SKILL.md`, new `slp-vaults.md` runbook (health, caps, rewards, raw keys), and `sai_perps_q` uses default `nibid` RPC.
- **Housekeeping**: Empty `ai-skills/.marksman.toml` stub for workspace tooling.

---

- **ai-skills(drill-spec): Number steps and persist drill decisions into specs or notes**
- **ai-skills(epics-plus): Add epic search mode, scan filters, and tighter Quick Start workflow**
- **ai-skills(nibiru-cli-nibid): Document get.nibiru.fi nibid installer URLs and behavior**
- **ai-skills(nibiru-cli-nibid): Drop hard-coded archive RPC from bank send example**
- **ai-skills(repo-map): Document NibiruChain remotes table and link cloning guide**
- **ai-skills(sai-perps-query): Expand SLP vault queries, cross-link nibid skill, default nibid RPC**
- **ai-skills(sai-perps-query): Normalize vault labels in mainnet address table**
- **ai-skills: Add empty Marksman workspace stub under ai-skills**
- **ai-skills(gh-pr-review): Add structured GitHub PR review playbook skill**
- **ai-skills(md-tasks): Add Markdown checkbox task conventions skill**
- **ai-skills(skill-creator): Add skill authoring bundle, Apache license, and validate scripts**
- **ai-skills(writing-tech): Add technical writing guidance skill and resource links**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-focused update; only minor operational risk is that examples now rely on local `nibid` config defaults (no hard-coded RPC), which could confuse users with misconfigured CLI settings.
> 
> **Overview**
> Refreshes the `ai-skills/` knowledge base with **new reusable playbooks** (`gh-pr-review`, `skill-creator`, `md-tasks`, `writing-tech`) and extends existing skills with clearer workflows and cross-references.
> 
> Improves operational guidance for planning and navigation by expanding `epics-plus` (search mode + scan/index usage), `repo-map` (GitHub remote mapping + cloning guide), and `drill-spec` (decision capture), and deepens Sai mainnet contract query docs by adding an SLP Vault runbook (`slp-vaults.md`) and updating examples to **use default `nibid` configuration** rather than pinned RPC flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95982b8152148074bc19bee4f5851afe1c7e9c03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->